### PR TITLE
98 logging

### DIFF
--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -75,9 +75,15 @@
     deploy:
       name: Deploy to DigitalOcean
       runs-on: ubuntu-latest
+      defaults:
+        run:
+          working-directory: ./
       needs: push
   
       steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
+
         - name: Configure SSH
           run: |
             mkdir -p ~/.ssh/
@@ -86,26 +92,45 @@
           env:
             TEST_ENV_SSH_SECRET_KEY: ${{ secrets.TEST_ENV_SSH_SECRET_KEY }}
   
+        - name: Deploy to Digital Ocean droplet via SSH action
+          env:
+            DOCKER_IMAGE: ${{ vars.DOCKER_USERNAME }}/minitwit:test
             ELASTIC_VERSION: ${{ vars.ELASTIC_VERSION }}
             ELASTIC_PASSWORD: ${{ secrets.ELASTIC_PASSWORD }}
             LOGSTASH_INTERNAL_PASSWORD: ${{ secrets.LOGSTASH_INTERNAL_PASSWORD }}
             KIBANA_SYSTEM_PASSWORD: ${{ secrets.KIBANA_SYSTEM_PASSWORD }}
-            METRICBEAT_INTERNAL_PASSWORD: ${{ secrets.METRICBEAT_INTERNAL_PASSWORD }}
             FILEBEAT_INTERNAL_PASSWORD: ${{ secrets.FILEBEAT_INTERNAL_PASSWORD }}
-            HEARTBEAT_INTERNAL_PASSWORD: ${{ secrets.HEARTBEAT_INTERNAL_PASSWORD }}
-            MONITORING_INTERNAL_PASSWORD: ${{ secrets.MONITORING_INTERNAL_PASSWORD }}
             BEATS_SYSTEM_PASSWORD: ${{ secrets.BEATS_SYSTEM_PASSWORD }}
-
-        - name: Deploy to Digital Ocean droplet via SSH action
-          env:
-            DOCKER_IMAGE: ${{ vars.DOCKER_USERNAME }}/minitwit:test
-          uses: appleboy/ssh-action@master
+          uses: 
+            appleboy/ssh-action@master
           with:
             host: ${{ vars.TEST_ENV_SSH_HOST }}
             username: ${{ vars.SSH_USER }}
             key: ${{ secrets.TEST_ENV_SSH_SECRET_KEY }}
-            envs: DOCKER_IMAGE
+            envs: DOCKER_IMAGE,ELASTIC_PASSWORD,KIBANA_SYSTEM_PASSWORD,LOGSTASH_INTERNAL_PASSWORD,FILEBEAT_INTERNAL_PASSWORD,BEATS_SYSTEM_PASSWORD
             script: |
-              docker rm $(docker stop $(docker ps -a --filter ancestor=$DOCKER_IMAGE --format="{{.ID}}"))
+              
+              if [ ! -d "/root/minitwit" ]; then
+                git clone https://github.com/DuwuOps/minitwit.git /root/minitwit
+                git checkout 98-logging
+                cd root/minitwit
+              else
+                cd /root/minitwit
+                git checkout 98-logging
+                git pull
+              fi
+              
+              export ELASTIC_VERSION=${ELASTIC_VERSION:-8.12.2}
+              export ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-changeme}
+              export KIBANA_SYSTEM_PASSWORD=${KIBANA_SYSTEM_PASSWORD:-changeme}
+              export LOGSTASH_INTERNAL_PASSWORD=${LOGSTASH_INTERNAL_PASSWORD:-changeme}
+              export FILEBEAT_INTERNAL_PASSWORD=${FILEBEAT_INTERNAL_PASSWORD:-changeme}
+              export BEATS_SYSTEM_PASSWORD=${BEATS_SYSTEM_PASSWORD:-changeme}
+
+              docker compose up setup
+              docker compose up -d
+
+              docker rm $(docker stop $(docker ps -a --filter ancestor=$DOCKER_IMAGE --format="{{.ID}}")) || true
               docker image pull $DOCKER_IMAGE
               sudo docker run -d -p 0.0.0.0:80:8000 --restart=always -v sqliteDB:/minitwit/tmp $DOCKER_IMAGE
+      

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -75,15 +75,9 @@
     deploy:
       name: Deploy to DigitalOcean
       runs-on: ubuntu-latest
-      defaults:
-        run:
-          working-directory: ./
       needs: push
   
       steps:
-        - name: Checkout code
-          uses: actions/checkout@v2
-
         - name: Configure SSH
           run: |
             mkdir -p ~/.ssh/
@@ -95,42 +89,13 @@
         - name: Deploy to Digital Ocean droplet via SSH action
           env:
             DOCKER_IMAGE: ${{ vars.DOCKER_USERNAME }}/minitwit:test
-            ELASTIC_VERSION: ${{ vars.ELASTIC_VERSION }}
-            ELASTIC_PASSWORD: ${{ secrets.ELASTIC_PASSWORD }}
-            LOGSTASH_INTERNAL_PASSWORD: ${{ secrets.LOGSTASH_INTERNAL_PASSWORD }}
-            KIBANA_SYSTEM_PASSWORD: ${{ secrets.KIBANA_SYSTEM_PASSWORD }}
-            FILEBEAT_INTERNAL_PASSWORD: ${{ secrets.FILEBEAT_INTERNAL_PASSWORD }}
-            BEATS_SYSTEM_PASSWORD: ${{ secrets.BEATS_SYSTEM_PASSWORD }}
-          uses: 
-            appleboy/ssh-action@master
+          uses: appleboy/ssh-action@master
           with:
             host: ${{ vars.TEST_ENV_SSH_HOST }}
             username: ${{ vars.SSH_USER }}
             key: ${{ secrets.TEST_ENV_SSH_SECRET_KEY }}
-            envs: DOCKER_IMAGE,ELASTIC_PASSWORD,KIBANA_SYSTEM_PASSWORD,LOGSTASH_INTERNAL_PASSWORD,FILEBEAT_INTERNAL_PASSWORD,BEATS_SYSTEM_PASSWORD
+            envs: DOCKER_IMAGE
             script: |
-              
-              if [ ! -d "/root/minitwit" ]; then
-                git clone https://github.com/DuwuOps/minitwit.git /root/minitwit
-                git checkout 98-logging
-                cd root/minitwit
-              else
-                cd /root/minitwit
-                git checkout 98-logging
-                git pull
-              fi
-              
-              export ELASTIC_VERSION=${ELASTIC_VERSION:-8.12.2}
-              export ELASTIC_PASSWORD=${ELASTIC_PASSWORD:-changeme}
-              export KIBANA_SYSTEM_PASSWORD=${KIBANA_SYSTEM_PASSWORD:-changeme}
-              export LOGSTASH_INTERNAL_PASSWORD=${LOGSTASH_INTERNAL_PASSWORD:-changeme}
-              export FILEBEAT_INTERNAL_PASSWORD=${FILEBEAT_INTERNAL_PASSWORD:-changeme}
-              export BEATS_SYSTEM_PASSWORD=${BEATS_SYSTEM_PASSWORD:-changeme}
-
-              docker compose up setup
-              docker compose up -d
-
-              docker rm $(docker stop $(docker ps -a --filter ancestor=$DOCKER_IMAGE --format="{{.ID}}")) || true
+              docker rm $(docker stop $(docker ps -a --filter ancestor=$DOCKER_IMAGE --format="{{.ID}}"))
               docker image pull $DOCKER_IMAGE
               sudo docker run -d -p 0.0.0.0:80:8000 --restart=always -v sqliteDB:/minitwit/tmp $DOCKER_IMAGE
-      

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -86,6 +86,16 @@
           env:
             TEST_ENV_SSH_SECRET_KEY: ${{ secrets.TEST_ENV_SSH_SECRET_KEY }}
   
+            ELASTIC_VERSION: ${{ vars.ELASTIC_VERSION }}
+            ELASTIC_PASSWORD: ${{ secrets.ELASTIC_PASSWORD }}
+            LOGSTASH_INTERNAL_PASSWORD: ${{ secrets.LOGSTASH_INTERNAL_PASSWORD }}
+            KIBANA_SYSTEM_PASSWORD: ${{ secrets.KIBANA_SYSTEM_PASSWORD }}
+            METRICBEAT_INTERNAL_PASSWORD: ${{ secrets.METRICBEAT_INTERNAL_PASSWORD }}
+            FILEBEAT_INTERNAL_PASSWORD: ${{ secrets.FILEBEAT_INTERNAL_PASSWORD }}
+            HEARTBEAT_INTERNAL_PASSWORD: ${{ secrets.HEARTBEAT_INTERNAL_PASSWORD }}
+            MONITORING_INTERNAL_PASSWORD: ${{ secrets.MONITORING_INTERNAL_PASSWORD }}
+            BEATS_SYSTEM_PASSWORD: ${{ secrets.BEATS_SYSTEM_PASSWORD }}
+
         - name: Deploy to Digital Ocean droplet via SSH action
           env:
             DOCKER_IMAGE: ${{ vars.DOCKER_USERNAME }}/minitwit:test

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ COPY --from=builder /build/minitwit .
 COPY ./src/templates ./templates
 COPY ./src/static ./static
 COPY ./src/queries ./queries
+COPY ./logging ./logging
 
 # Expose port and run binary-file
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,5 @@ COPY ./src/queries ./queries
 COPY ./logging ./logging
 
 # Expose port and run binary-file
-EXPOSE 8000
+EXPOSE 8000 
 CMD ["./minitwit"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,117 @@ services:
       - sqliteDB:/minitwit/tmp
     ports:
       - 8000:8000
+
+# The 'setup' service runs a one-off script which initializes users inside
+  # Elasticsearch — such as 'logstash_internal' and 'kibana_system' — with the
+  # values of the passwords defined in the '.env' file. It also creates the
+  # roles required by some of these users.
+  #
+  # This task only needs to be performed once, during the *initial* startup of
+  # the stack. Any subsequent run will reset the passwords of existing users to
+  # the values defined inside the '.env' file, and the built-in roles to their
+  # default permissions.
+  #
+  # By default, it is excluded from the services started by 'docker compose up'
+  # due to the non-default profile it belongs to. To run it, either provide the
+  # '--profile=setup' CLI flag to Compose commands, or "up" the service by name
+  # such as 'docker compose up setup'.
+  setup:
+    profiles:
+      - setup
+    build:
+      context: logging/setup/
+      args:
+        ELASTIC_VERSION: ${ELASTIC_VERSION}
+    init: true
+    volumes:
+      - ./logging/setup/entrypoint.sh:/entrypoint.sh:ro,Z
+      - ./logging/setup/lib.sh:/lib.sh:ro,Z
+      - ./logging/setup/roles:/roles:ro,Z
+    environment:
+      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD:-}
+      LOGSTASH_INTERNAL_PASSWORD: ${LOGSTASH_INTERNAL_PASSWORD:-}
+      KIBANA_SYSTEM_PASSWORD: ${KIBANA_SYSTEM_PASSWORD:-}
+      METRICBEAT_INTERNAL_PASSWORD: ${METRICBEAT_INTERNAL_PASSWORD:-}
+      FILEBEAT_INTERNAL_PASSWORD: ${FILEBEAT_INTERNAL_PASSWORD:-}
+      HEARTBEAT_INTERNAL_PASSWORD: ${HEARTBEAT_INTERNAL_PASSWORD:-}
+      MONITORING_INTERNAL_PASSWORD: ${MONITORING_INTERNAL_PASSWORD:-}
+      BEATS_SYSTEM_PASSWORD: ${BEATS_SYSTEM_PASSWORD:-}
+    networks:
+      - elk
+    depends_on:
+      - elasticsearch
+
+  elasticsearch:
+    build:
+      context: logging/elasticsearch/
+      args:
+        ELASTIC_VERSION: ${ELASTIC_VERSION}
+    volumes:
+      - ./logging/elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro,Z
+      - elasticsearch:/usr/share/elasticsearch/data:Z
+    ports:
+      - 9200:9200 # Main Elasticsearch input
+    environment:
+      node.name: elasticsearch
+      ES_JAVA_OPTS: -Xms512m -Xmx512m
+      # Bootstrap password.
+      # Used to initialize the keystore during the initial startup of
+      # Elasticsearch. Ignored on subsequent runs.
+      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD:-}
+      # Use single node discovery in order to disable production mode and avoid bootstrap checks.
+      # see: https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html
+      discovery.type: single-node
+    networks:
+      - elk
+    restart: unless-stopped
+
+  logstash:
+    build:
+      context: logging/logstash/
+      args:
+        ELASTIC_VERSION: ${ELASTIC_VERSION}
+    volumes:
+      - ./logging/logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro,Z
+      - ./logging/logstash/pipeline:/usr/share/logstash/pipeline:ro,Z
+    ports:
+      - 5044:5044 # Beats input
+    environment:
+      LS_JAVA_OPTS: -Xms256m -Xmx256m
+      LOGSTASH_INTERNAL_PASSWORD: ${LOGSTASH_INTERNAL_PASSWORD:-}
+    networks:
+      - elk
+    depends_on:
+      - elasticsearch
+    restart: unless-stopped
+
+  filebeat:
+    extends:
+      file: ./logging/filebeat/filebeat-compose.yml
+      service: filebeat
+
+  kibana:
+    build:
+      context: logging/kibana/
+      args:
+        ELASTIC_VERSION: ${ELASTIC_VERSION}
+    volumes:
+      - ./logging/kibana/config/kibana.yml:/usr/share/kibana/config/kibana.yml:ro,Z
+    ports:
+      - 5601:5601 # Kibana UI Dashboard
+    environment:
+      KIBANA_SYSTEM_PASSWORD: ${KIBANA_SYSTEM_PASSWORD:-}
+    networks:
+      - elk
+    depends_on:
+      - elasticsearch
+    restart: unless-stopped
+
+networks:
+  elk:
+    driver: bridge
+  main:
+
 volumes:
   sqliteDB:
+  elasticsearch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,21 +28,21 @@ services:
     build:
       context: logging/setup/
       args:
-        ELASTIC_VERSION: ${ELASTIC_VERSION}
+        ELASTIC_VERSION: ${ELASTIC_VERSION:-8.12.2}
     init: true
     volumes:
       - ./logging/setup/entrypoint.sh:/entrypoint.sh:ro,Z
       - ./logging/setup/lib.sh:/lib.sh:ro,Z
       - ./logging/setup/roles:/roles:ro,Z
     environment:
-      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD:-}
-      LOGSTASH_INTERNAL_PASSWORD: ${LOGSTASH_INTERNAL_PASSWORD:-}
-      KIBANA_SYSTEM_PASSWORD: ${KIBANA_SYSTEM_PASSWORD:-}
+      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD:-changeme}
+      LOGSTASH_INTERNAL_PASSWORD: ${LOGSTASH_INTERNAL_PASSWORD:-changeme}
+      KIBANA_SYSTEM_PASSWORD: ${KIBANA_SYSTEM_PASSWORD:-changeme}
       METRICBEAT_INTERNAL_PASSWORD: ${METRICBEAT_INTERNAL_PASSWORD:-}
-      FILEBEAT_INTERNAL_PASSWORD: ${FILEBEAT_INTERNAL_PASSWORD:-}
+      FILEBEAT_INTERNAL_PASSWORD: ${FILEBEAT_INTERNAL_PASSWORD:-changeme}
       HEARTBEAT_INTERNAL_PASSWORD: ${HEARTBEAT_INTERNAL_PASSWORD:-}
       MONITORING_INTERNAL_PASSWORD: ${MONITORING_INTERNAL_PASSWORD:-}
-      BEATS_SYSTEM_PASSWORD: ${BEATS_SYSTEM_PASSWORD:-}
+      BEATS_SYSTEM_PASSWORD: ${BEATS_SYSTEM_PASSWORD:-changeme}
     networks:
       - elk
     depends_on:
@@ -52,7 +52,7 @@ services:
     build:
       context: logging/elasticsearch/
       args:
-        ELASTIC_VERSION: ${ELASTIC_VERSION}
+        ELASTIC_VERSION: ${ELASTIC_VERSION:-8.12.2}
     volumes:
       - ./logging/elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro,Z
       - elasticsearch:/usr/share/elasticsearch/data:Z
@@ -64,7 +64,7 @@ services:
       # Bootstrap password.
       # Used to initialize the keystore during the initial startup of
       # Elasticsearch. Ignored on subsequent runs.
-      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD:-}
+      ELASTIC_PASSWORD: ${ELASTIC_PASSWORD:-changeme}
       # Use single node discovery in order to disable production mode and avoid bootstrap checks.
       # see: https://www.elastic.co/guide/en/elasticsearch/reference/current/bootstrap-checks.html
       discovery.type: single-node
@@ -76,7 +76,7 @@ services:
     build:
       context: logging/logstash/
       args:
-        ELASTIC_VERSION: ${ELASTIC_VERSION}
+        ELASTIC_VERSION: ${ELASTIC_VERSION:-8.12.2}
     volumes:
       - ./logging/logstash/config/logstash.yml:/usr/share/logstash/config/logstash.yml:ro,Z
       - ./logging/logstash/pipeline:/usr/share/logstash/pipeline:ro,Z
@@ -84,7 +84,7 @@ services:
       - 5044:5044 # Beats input
     environment:
       LS_JAVA_OPTS: -Xms256m -Xmx256m
-      LOGSTASH_INTERNAL_PASSWORD: ${LOGSTASH_INTERNAL_PASSWORD:-}
+      LOGSTASH_INTERNAL_PASSWORD: ${LOGSTASH_INTERNAL_PASSWORD:-changeme}
     networks:
       - elk
     depends_on:
@@ -100,13 +100,13 @@ services:
     build:
       context: logging/kibana/
       args:
-        ELASTIC_VERSION: ${ELASTIC_VERSION}
+        ELASTIC_VERSION: ${ELASTIC_VERSION:-8.12.2}
     volumes:
       - ./logging/kibana/config/kibana.yml:/usr/share/kibana/config/kibana.yml:ro,Z
     ports:
       - 5601:5601 # Kibana UI Dashboard
     environment:
-      KIBANA_SYSTEM_PASSWORD: ${KIBANA_SYSTEM_PASSWORD:-}
+      KIBANA_SYSTEM_PASSWORD: ${KIBANA_SYSTEM_PASSWORD:-changeme}
     networks:
       - elk
     depends_on:

--- a/logging/elasticsearch/.dockerignore
+++ b/logging/elasticsearch/.dockerignore
@@ -1,0 +1,6 @@
+# Ignore Docker build files
+Dockerfile
+.dockerignore
+
+# Ignore OS artifacts
+**/.DS_Store

--- a/logging/elasticsearch/Dockerfile
+++ b/logging/elasticsearch/Dockerfile
@@ -1,0 +1,7 @@
+ARG ELASTIC_VERSION
+
+# https://www.docker.elastic.co/
+FROM docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
+
+# Add your elasticsearch plugins setup here
+# Example: RUN elasticsearch-plugin install analysis-icu

--- a/logging/elasticsearch/Dockerfile
+++ b/logging/elasticsearch/Dockerfile
@@ -1,7 +1,7 @@
 ARG ELASTIC_VERSION
 
 # https://www.docker.elastic.co/
-FROM docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
+FROM docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.12.2}
 
 # Add your elasticsearch plugins setup here
 # Example: RUN elasticsearch-plugin install analysis-icu

--- a/logging/elasticsearch/config/elasticsearch.yml
+++ b/logging/elasticsearch/config/elasticsearch.yml
@@ -1,0 +1,12 @@
+---
+## Default Elasticsearch configuration from Elasticsearch base image.
+## https://github.com/elastic/elasticsearch/blob/main/distribution/docker/src/docker/config/elasticsearch.yml
+#
+cluster.name: docker-cluster
+network.host: 0.0.0.0
+
+## X-Pack settings
+## see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html
+#
+xpack.license.self_generated.type: trial
+xpack.security.enabled: true

--- a/logging/filebeat/.dockerignore
+++ b/logging/filebeat/.dockerignore
@@ -1,0 +1,6 @@
+# Ignore Docker build files
+Dockerfile
+.dockerignore
+
+# Ignore OS artifacts
+**/.DS_Store

--- a/logging/filebeat/Dockerfile
+++ b/logging/filebeat/Dockerfile
@@ -1,0 +1,3 @@
+ARG ELASTIC_VERSION
+
+FROM docker.elastic.co/beats/filebeat:${ELASTIC_VERSION}

--- a/logging/filebeat/Dockerfile
+++ b/logging/filebeat/Dockerfile
@@ -1,3 +1,3 @@
 ARG ELASTIC_VERSION
 
-FROM docker.elastic.co/beats/filebeat:${ELASTIC_VERSION}
+FROM docker.elastic.co/beats/filebeat:${ELASTIC_VERSION:-8.12.2}

--- a/logging/filebeat/README.md
+++ b/logging/filebeat/README.md
@@ -1,0 +1,42 @@
+# Filebeat
+
+Filebeat is a lightweight shipper for forwarding and centralizing log data. Installed as an agent on your servers,
+Filebeat monitors the log files or locations that you specify, collects log events, and forwards them either to
+Elasticsearch or Logstash for indexing.
+
+## Usage
+
+**This extension requires the `filebeat_internal` and `beats_system` users to be created and initialized with a
+password.** In case you haven't done that during the initial startup of the stack, please refer to [How to re-execute
+the setup][setup] to run the setup container again and initialize these users.
+
+To include Filebeat in the stack, run Docker Compose from the root of the repository with an additional command line
+argument referencing the `filebeat-compose.yml` file:
+
+```console
+$ docker-compose -f docker-compose.yml -f extensions/filebeat/filebeat-compose.yml up
+```
+
+## Configuring Filebeat
+
+The Filebeat configuration is stored in [`config/filebeat.yml`](./config/filebeat.yml). You can modify this file with
+the help of the [Configuration reference][filebeat-config].
+
+Any change to the Filebeat configuration requires a restart of the Filebeat container:
+
+```console
+$ docker-compose -f docker-compose.yml -f extensions/filebeat/filebeat-compose.yml restart filebeat
+```
+
+Please refer to the following documentation page for more details about how to configure Filebeat inside a Docker
+container: [Run Filebeat on Docker][filebeat-docker].
+
+## See also
+
+[Filebeat documentation][filebeat-doc]
+
+[filebeat-config]: https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-reference-yml.html
+[filebeat-docker]: https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html
+[filebeat-doc]: https://www.elastic.co/guide/en/beats/filebeat/current/index.html
+
+[setup]: ../../README.md#how-to-re-execute-the-setup

--- a/logging/filebeat/config/filebeat.yml
+++ b/logging/filebeat/config/filebeat.yml
@@ -1,0 +1,25 @@
+name: filebeat
+
+filebeat.autodiscover:
+  providers:
+    # The Docker autodiscover provider automatically retrieves logs from Docker
+    # containers as they start and stop.
+    - type: docker
+      hints.enabled: true
+      hints.default_config:
+        type: container
+        paths:
+          - /var/lib/docker/containers/${data.container.id}/*-json.log
+
+monitoring:
+  enabled: true
+  elasticsearch:
+    hosts: ["http://elasticsearch:9200"]
+    username: beats_system
+    password: ${BEATS_SYSTEM_PASSWORD}
+
+
+output.logstash:
+  hosts: ["logstash:5044"]
+
+

--- a/logging/filebeat/filebeat-compose.yml
+++ b/logging/filebeat/filebeat-compose.yml
@@ -1,0 +1,35 @@
+version: '3.7'
+
+services:
+  filebeat:
+    build:
+      context: .
+      args:
+        ELASTIC_VERSION: ${ELASTIC_VERSION}
+    # Run as 'root' instead of 'filebeat' (uid 1000) to allow reading
+    # 'docker.sock' and the host's filesystem.
+    user: root
+    command:
+      # Log to stderr.
+      - -e
+      # Disable config file permissions checks. Allows mounting
+      # 'config/filebeat.yml' even if it's not owned by root.
+      # see: https://www.elastic.co/guide/en/beats/libbeat/current/config-file-permissions.html
+      - --strict.perms=false
+    volumes:
+      - ./config/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro,Z
+      - type: bind
+        source: /var/lib/docker/containers
+        target: /var/lib/docker/containers
+        read_only: true
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+        read_only: true
+    environment:
+      FILEBEAT_INTERNAL_PASSWORD: ${FILEBEAT_INTERNAL_PASSWORD:-}
+      BEATS_SYSTEM_PASSWORD: ${BEATS_SYSTEM_PASSWORD:-}
+    networks:
+      - elk
+    depends_on:
+      - elasticsearch

--- a/logging/filebeat/filebeat-compose.yml
+++ b/logging/filebeat/filebeat-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       args:
-        ELASTIC_VERSION: ${ELASTIC_VERSION}
+        ELASTIC_VERSION: ${ELASTIC_VERSION:-8.12.2}
     # Run as 'root' instead of 'filebeat' (uid 1000) to allow reading
     # 'docker.sock' and the host's filesystem.
     user: root
@@ -27,8 +27,8 @@ services:
         target: /var/run/docker.sock
         read_only: true
     environment:
-      FILEBEAT_INTERNAL_PASSWORD: ${FILEBEAT_INTERNAL_PASSWORD:-}
-      BEATS_SYSTEM_PASSWORD: ${BEATS_SYSTEM_PASSWORD:-}
+      FILEBEAT_INTERNAL_PASSWORD: ${FILEBEAT_INTERNAL_PASSWORD:-changeme}
+      BEATS_SYSTEM_PASSWORD: ${BEATS_SYSTEM_PASSWORD:-changeme}
     networks:
       - elk
     depends_on:

--- a/logging/kibana/.dockerignore
+++ b/logging/kibana/.dockerignore
@@ -1,0 +1,6 @@
+# Ignore Docker build files
+Dockerfile
+.dockerignore
+
+# Ignore OS artifacts
+**/.DS_Store

--- a/logging/kibana/Dockerfile
+++ b/logging/kibana/Dockerfile
@@ -1,0 +1,7 @@
+ARG ELASTIC_VERSION
+
+# https://www.docker.elastic.co/
+FROM docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
+
+# Add your kibana plugins setup here
+# Example: RUN kibana-plugin install <name|url>

--- a/logging/kibana/Dockerfile
+++ b/logging/kibana/Dockerfile
@@ -1,7 +1,7 @@
 ARG ELASTIC_VERSION
 
 # https://www.docker.elastic.co/
-FROM docker.elastic.co/kibana/kibana:${ELASTIC_VERSION}
+FROM docker.elastic.co/kibana/kibana:${ELASTIC_VERSION:-8.12.2}
 
 # Add your kibana plugins setup here
 # Example: RUN kibana-plugin install <name|url>

--- a/logging/kibana/config/kibana.yml
+++ b/logging/kibana/config/kibana.yml
@@ -1,0 +1,10 @@
+server.name: kibana
+server.host: 0.0.0.0
+elasticsearch.hosts: [ http://elasticsearch:9200 ]
+
+monitoring.ui.container.elasticsearch.enabled: true
+monitoring.ui.container.logstash.enabled: true
+
+elasticsearch.username: kibana_system
+elasticsearch.password: ${KIBANA_SYSTEM_PASSWORD}
+

--- a/logging/logstash/.dockerignore
+++ b/logging/logstash/.dockerignore
@@ -1,0 +1,6 @@
+# Ignore Docker build files
+Dockerfile
+.dockerignore
+
+# Ignore OS artifacts
+**/.DS_Store

--- a/logging/logstash/Dockerfile
+++ b/logging/logstash/Dockerfile
@@ -1,0 +1,7 @@
+ARG ELASTIC_VERSION
+
+# https://www.docker.elastic.co/
+FROM docker.elastic.co/logstash/logstash:${ELASTIC_VERSION}
+
+# Add your logstash plugins setup here
+# Example: RUN logstash-plugin install logstash-filter-json

--- a/logging/logstash/Dockerfile
+++ b/logging/logstash/Dockerfile
@@ -1,7 +1,7 @@
 ARG ELASTIC_VERSION
 
 # https://www.docker.elastic.co/
-FROM docker.elastic.co/logstash/logstash:${ELASTIC_VERSION}
+FROM docker.elastic.co/logstash/logstash:${ELASTIC_VERSION:-8.12.2}
 
 # Add your logstash plugins setup here
 # Example: RUN logstash-plugin install logstash-filter-json

--- a/logging/logstash/config/logstash.yml
+++ b/logging/logstash/config/logstash.yml
@@ -1,0 +1,7 @@
+---
+## Default Logstash configuration from Logstash base image.
+## https://github.com/elastic/logstash/blob/main/docker/data/logstash/config/logstash-full.yml
+#
+http.host: 0.0.0.0
+
+node.name: logstash

--- a/logging/logstash/pipeline/logstash.conf
+++ b/logging/logstash/pipeline/logstash.conf
@@ -1,0 +1,36 @@
+input {
+	beats {
+		port => 5044
+	}
+}
+
+filter {
+  # Extract the fields from the 'message' field using Grok
+  grok {
+    match => { "message" => "%{WORD:log_level}:%{WORD:logger}:%{IP:client_ip} - - \[%{NUMBER:day}/%{WORD:month}/%{NUMBER:year} %{TIME:time}\] \"%{WORD:http_method} %{URIPATHPARAM:path} HTTP/%{NUMBER:http_version}\" %{NUMBER:response_code}(?: -)?" }
+  }
+
+  # Check if the grok filter successfully matched
+  if "_grokparsefailure" not in [tags] {
+    # Optional: You can mutate to add more tags or perform other actions here if needed.
+    mutate {
+      add_field => {
+        "extracted_message" => "Method: %{http_method}, Path: %{path}, Response: %{response_code}"
+      }
+    }
+  } else {
+    # If Grok parsing failed, add a tag to notify for debugging
+    mutate {
+      add_tag => ["_grokparsefailure"]
+    }
+  }
+}
+
+
+output {
+	elasticsearch {
+		hosts => "elasticsearch:9200"
+		user => "logstash_internal"
+		password => "${LOGSTASH_INTERNAL_PASSWORD}"
+	}
+}

--- a/logging/setup/.dockerignore
+++ b/logging/setup/.dockerignore
@@ -1,0 +1,9 @@
+# Ignore Docker build files
+Dockerfile
+.dockerignore
+
+# Ignore OS artifacts
+**/.DS_Store
+
+# Ignore Git files
+.gitignore

--- a/logging/setup/Dockerfile
+++ b/logging/setup/Dockerfile
@@ -1,0 +1,6 @@
+ARG ELASTIC_VERSION
+
+# https://www.docker.elastic.co/
+FROM docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/logging/setup/Dockerfile
+++ b/logging/setup/Dockerfile
@@ -1,6 +1,6 @@
 ARG ELASTIC_VERSION
 
 # https://www.docker.elastic.co/
-FROM docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
+FROM docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.12.2}
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/logging/setup/entrypoint.sh
+++ b/logging/setup/entrypoint.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+source "${BASH_SOURCE[0]%/*}"/lib.sh
+
+
+# --------------------------------------------------------
+# Users declarations
+
+declare -A users_passwords
+users_passwords=(
+	[logstash_internal]="${LOGSTASH_INTERNAL_PASSWORD:-}"
+	[kibana_system]="${KIBANA_SYSTEM_PASSWORD:-}"
+	[metricbeat_internal]="${METRICBEAT_INTERNAL_PASSWORD:-}"
+	[filebeat_internal]="${FILEBEAT_INTERNAL_PASSWORD:-}"
+	[heartbeat_internal]="${HEARTBEAT_INTERNAL_PASSWORD:-}"
+	[monitoring_internal]="${MONITORING_INTERNAL_PASSWORD:-}"
+	[beats_system]="${BEATS_SYSTEM_PASSWORD=:-}"
+)
+
+declare -A users_roles
+users_roles=(
+	[logstash_internal]='logstash_writer'
+	[metricbeat_internal]='metricbeat_writer'
+	[filebeat_internal]='filebeat_writer'
+	[heartbeat_internal]='heartbeat_writer'
+	[monitoring_internal]='remote_monitoring_collector'
+)
+
+# --------------------------------------------------------
+# Roles declarations
+
+declare -A roles_files
+roles_files=(
+	[logstash_writer]='logstash_writer.json'
+	[metricbeat_writer]='metricbeat_writer.json'
+	[filebeat_writer]='filebeat_writer.json'
+	[heartbeat_writer]='heartbeat_writer.json'
+)
+
+# --------------------------------------------------------
+
+
+log 'Waiting for availability of Elasticsearch. This can take several minutes.'
+
+declare -i exit_code=0
+wait_for_elasticsearch || exit_code=$?
+
+if ((exit_code)); then
+	case $exit_code in
+		6)
+			suberr 'Could not resolve host. Is Elasticsearch running?'
+			;;
+		7)
+			suberr 'Failed to connect to host. Is Elasticsearch healthy?'
+			;;
+		28)
+			suberr 'Timeout connecting to host. Is Elasticsearch healthy?'
+			;;
+		*)
+			suberr "Connection to Elasticsearch failed. Exit code: ${exit_code}"
+			;;
+	esac
+
+	exit $exit_code
+fi
+
+sublog 'Elasticsearch is running'
+
+log 'Waiting for initialization of built-in users'
+
+wait_for_builtin_users || exit_code=$?
+
+if ((exit_code)); then
+	suberr 'Timed out waiting for condition'
+	exit $exit_code
+fi
+
+sublog 'Built-in users were initialized'
+
+for role in "${!roles_files[@]}"; do
+	log "Role '$role'"
+
+	declare body_file
+	body_file="${BASH_SOURCE[0]%/*}/roles/${roles_files[$role]:-}"
+	if [[ ! -f "${body_file:-}" ]]; then
+		sublog "No role body found at '${body_file}', skipping"
+		continue
+	fi
+
+	sublog 'Creating/updating'
+	ensure_role "$role" "$(<"${body_file}")"
+done
+
+for user in "${!users_passwords[@]}"; do
+	log "User '$user'"
+	if [[ -z "${users_passwords[$user]:-}" ]]; then
+		sublog 'No password defined, skipping'
+		continue
+	fi
+
+	declare -i user_exists=0
+	user_exists="$(check_user_exists "$user")"
+
+	if ((user_exists)); then
+		sublog 'User exists, setting password'
+		set_user_password "$user" "${users_passwords[$user]}"
+	else
+		if [[ -z "${users_roles[$user]:-}" ]]; then
+			suberr '  No role defined, skipping creation'
+			continue
+		fi
+
+		sublog 'User does not exist, creating'
+		create_user "$user" "${users_passwords[$user]}" "${users_roles[$user]}"
+	fi
+done

--- a/logging/setup/entrypoint.sh
+++ b/logging/setup/entrypoint.sh
@@ -11,13 +11,13 @@ source "${BASH_SOURCE[0]%/*}"/lib.sh
 
 declare -A users_passwords
 users_passwords=(
-	[logstash_internal]="${LOGSTASH_INTERNAL_PASSWORD:-}"
-	[kibana_system]="${KIBANA_SYSTEM_PASSWORD:-}"
+	[logstash_internal]="${LOGSTASH_INTERNAL_PASSWORD:-changeme}"
+	[kibana_system]="${KIBANA_SYSTEM_PASSWORD:-changeme}"
 	[metricbeat_internal]="${METRICBEAT_INTERNAL_PASSWORD:-}"
-	[filebeat_internal]="${FILEBEAT_INTERNAL_PASSWORD:-}"
+	[filebeat_internal]="${FILEBEAT_INTERNAL_PASSWORD:-changeme}"
 	[heartbeat_internal]="${HEARTBEAT_INTERNAL_PASSWORD:-}"
 	[monitoring_internal]="${MONITORING_INTERNAL_PASSWORD:-}"
-	[beats_system]="${BEATS_SYSTEM_PASSWORD=:-}"
+	[beats_system]="${BEATS_SYSTEM_PASSWORD=:-changeme}"
 )
 
 declare -A users_roles

--- a/logging/setup/lib.sh
+++ b/logging/setup/lib.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+
+# Log a message.
+function log {
+	echo "[+] $1"
+}
+
+# Log a message at a sub-level.
+function sublog {
+	echo "   ⠿ $1"
+}
+
+# Log an error.
+function err {
+	echo "[x] $1" >&2
+}
+
+# Log an error at a sub-level.
+function suberr {
+	echo "   ⠍ $1" >&2
+}
+
+# Poll the 'elasticsearch' service until it responds with HTTP code 200.
+function wait_for_elasticsearch {
+	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+
+	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}' "http://${elasticsearch_host}:9200/" )
+
+	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+	fi
+
+	local -i result=1
+	local output
+
+	# retry for max 300s (60*5s)
+	for _ in $(seq 1 60); do
+		local -i exit_code=0
+		output="$(curl "${args[@]}")" || exit_code=$?
+
+		if ((exit_code)); then
+			result=$exit_code
+		fi
+
+		if [[ "${output: -3}" -eq 200 ]]; then
+			result=0
+			break
+		fi
+
+		sleep 5
+	done
+
+	if ((result)) && [[ "${output: -3}" -ne 000 ]]; then
+		echo -e "\n${output::-3}"
+	fi
+
+	return $result
+}
+
+# Poll the Elasticsearch users API until it returns users.
+function wait_for_builtin_users {
+	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+
+	local -a args=( '-s' '-D-' '-m15' "http://${elasticsearch_host}:9200/_security/user?pretty" )
+
+	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+	fi
+
+	local -i result=1
+
+	local line
+	local -i exit_code
+	local -i num_users
+
+	# retry for max 30s (30*1s)
+	for _ in $(seq 1 30); do
+		num_users=0
+
+		# read exits with a non-zero code if the last read input doesn't end
+		# with a newline character. The printf without newline that follows the
+		# curl command ensures that the final input not only contains curl's
+		# exit code, but causes read to fail so we can capture the return value.
+		# Ref. https://unix.stackexchange.com/a/176703/152409
+		while IFS= read -r line || ! exit_code="$line"; do
+			if [[ "$line" =~ _reserved.+true ]]; then
+				(( num_users++ ))
+			fi
+		done < <(curl "${args[@]}"; printf '%s' "$?")
+
+		if ((exit_code)); then
+			result=$exit_code
+		fi
+
+		# we expect more than just the 'elastic' user in the result
+		if (( num_users > 1 )); then
+			result=0
+			break
+		fi
+
+		sleep 1
+	done
+
+	return $result
+}
+
+# Verify that the given Elasticsearch user exists.
+function check_user_exists {
+	local username=$1
+
+	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+
+	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
+		"http://${elasticsearch_host}:9200/_security/user/${username}"
+		)
+
+	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+	fi
+
+	local -i result=1
+	local -i exists=0
+	local output
+
+	output="$(curl "${args[@]}")"
+	if [[ "${output: -3}" -eq 200 || "${output: -3}" -eq 404 ]]; then
+		result=0
+	fi
+	if [[ "${output: -3}" -eq 200 ]]; then
+		exists=1
+	fi
+
+	if ((result)); then
+		echo -e "\n${output::-3}"
+	else
+		echo "$exists"
+	fi
+
+	return $result
+}
+
+# Set password of a given Elasticsearch user.
+function set_user_password {
+	local username=$1
+	local password=$2
+
+	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+
+	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
+		"http://${elasticsearch_host}:9200/_security/user/${username}/_password"
+		'-X' 'POST'
+		'-H' 'Content-Type: application/json'
+		'-d' "{\"password\" : \"${password}\"}"
+		)
+
+	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+	fi
+
+	local -i result=1
+	local output
+
+	output="$(curl "${args[@]}")"
+	if [[ "${output: -3}" -eq 200 ]]; then
+		result=0
+	fi
+
+	if ((result)); then
+		echo -e "\n${output::-3}\n"
+	fi
+
+	return $result
+}
+
+# Create the given Elasticsearch user.
+function create_user {
+	local username=$1
+	local password=$2
+	local role=$3
+
+	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+
+	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
+		"http://${elasticsearch_host}:9200/_security/user/${username}"
+		'-X' 'POST'
+		'-H' 'Content-Type: application/json'
+		'-d' "{\"password\":\"${password}\",\"roles\":[\"${role}\"]}"
+		)
+
+	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+	fi
+
+	local -i result=1
+	local output
+
+	output="$(curl "${args[@]}")"
+	if [[ "${output: -3}" -eq 200 ]]; then
+		result=0
+	fi
+
+	if ((result)); then
+		echo -e "\n${output::-3}\n"
+	fi
+
+	return $result
+}
+
+# Ensure that the given Elasticsearch role is up-to-date, create it if required.
+function ensure_role {
+	local name=$1
+	local body=$2
+
+	local elasticsearch_host="${ELASTICSEARCH_HOST:-elasticsearch}"
+
+	local -a args=( '-s' '-D-' '-m15' '-w' '%{http_code}'
+		"http://${elasticsearch_host}:9200/_security/role/${name}"
+		'-X' 'POST'
+		'-H' 'Content-Type: application/json'
+		'-d' "$body"
+		)
+
+	if [[ -n "${ELASTIC_PASSWORD:-}" ]]; then
+		args+=( '-u' "elastic:${ELASTIC_PASSWORD}" )
+	fi
+
+	local -i result=1
+	local output
+
+	output="$(curl "${args[@]}")"
+	if [[ "${output: -3}" -eq 200 ]]; then
+		result=0
+	fi
+
+	if ((result)); then
+		echo -e "\n${output::-3}\n"
+	fi
+
+	return $result
+}

--- a/logging/setup/roles/filebeat_writer.json
+++ b/logging/setup/roles/filebeat_writer.json
@@ -1,0 +1,20 @@
+{
+  "cluster": [
+    "manage_ilm",
+    "manage_index_templates",
+    "manage_ingest_pipelines",
+    "monitor",
+    "read_pipeline"
+  ],
+  "indices": [
+    {
+      "names": [
+        "filebeat-*"
+      ],
+      "privileges": [
+        "create_doc",
+        "manage"
+      ]
+    }
+  ]
+}

--- a/logging/setup/roles/heartbeat_writer.json
+++ b/logging/setup/roles/heartbeat_writer.json
@@ -1,0 +1,18 @@
+{
+  "cluster": [
+    "manage_ilm",
+    "manage_index_templates",
+    "monitor"
+  ],
+  "indices": [
+    {
+      "names": [
+        "heartbeat-*"
+      ],
+      "privileges": [
+        "create_doc",
+        "manage"
+      ]
+    }
+  ]
+}

--- a/logging/setup/roles/logstash_writer.json
+++ b/logging/setup/roles/logstash_writer.json
@@ -1,0 +1,33 @@
+{
+  "cluster": [
+    "manage_index_templates",
+    "monitor",
+    "manage_ilm"
+  ],
+  "indices": [
+    {
+      "names": [
+        "logs-generic-default",
+        "logstash-*",
+        "ecs-logstash-*"
+      ],
+      "privileges": [
+        "write",
+        "create",
+        "create_index",
+        "manage",
+        "manage_ilm"
+      ]
+    },
+    {
+      "names": [
+        "logstash",
+        "ecs-logstash"
+      ],
+      "privileges": [
+        "write",
+        "manage"
+      ]
+    }
+  ]
+}

--- a/logging/setup/roles/metricbeat_writer.json
+++ b/logging/setup/roles/metricbeat_writer.json
@@ -1,0 +1,19 @@
+{
+  "cluster": [
+    "manage_ilm",
+    "manage_index_templates",
+    "monitor"
+  ],
+  "indices": [
+    {
+      "names": [
+        ".monitoring-*-mb",
+        "metricbeat-*"
+      ],
+      "privileges": [
+        "create_doc",
+        "manage"
+      ]
+    }
+  ]
+}

--- a/src/datalayer/database.go
+++ b/src/datalayer/database.go
@@ -86,9 +86,7 @@ func QueryDbSingle(db *sql.DB, query string, args ...any) *sql.Row {
 }
 
 func QueryDB(db *sql.DB, query string, args ...any) (*sql.Rows, error) {
-	fmt.Printf("\nqueryDB called with following arguments:\n")
-	fmt.Printf(" - query: %v\n", query)
-	fmt.Printf(" - args: %v\n\n", args)
+	fmt.Printf("\nqueryDB called with following arguments:\n - query: %v\n - args: %v\n\n", query, args)
 
 	//Queries the database and returns a list of QueryResults.
 	if db == nil {


### PR DESCRIPTION
**Purpose**

* Add logging

**Changes**
* Adds a logging folder to the repository, all files of which originate from https://github.com/itu-devops/itu-minitwit-logging.
* Significantly updates the `docker-compose.yml` file to setup elasticsearch, kibana, filebeat and logstash.

* The stack is initialized with:
```
docker compose up setup
docker compose up -d
```
If no password variables or `.env` file is provided, passwords will default to "changeme". 
The logs are accessed via. port 5601.

**Further Work**

* As seen in section [Basics of how to use Kibana](https://github.com/itu-devops/itu-minitwit-logging?tab=readme-ov-file#basics-of-how-to-use-kibana) you can (or should) set up different data views. 
I suggest we start with one that has 'message' information, just because it shows information that is easily mapped to user actions.

**Task Relations:**

* Closes #98

![image](https://github.com/user-attachments/assets/2908bec1-ade3-4a0d-8444-f58107d9c27f)
