### PR TITLE
108 grafana logging

### DIFF
--- a/.infrastructure/alloy/Dockerfile
+++ b/.infrastructure/alloy/Dockerfile
@@ -1,0 +1,5 @@
+FROM grafana/alloy:latest
+
+COPY alloy-config.alloy /etc/alloy/alloy-config.alloy
+
+EXPOSE 12345

--- a/.infrastructure/alloy/Dockerfile
+++ b/.infrastructure/alloy/Dockerfile
@@ -4,4 +4,3 @@ COPY alloy-config.alloy /etc/alloy/alloy-config.alloy
 
 CMD ["run", "--server.http.listen-addr=0.0.0.0:12345", "--storage.path=/var/lib/alloy/data", "/etc/alloy/alloy-config.alloy"]
 
-EXPOSE 12345

--- a/.infrastructure/alloy/Dockerfile
+++ b/.infrastructure/alloy/Dockerfile
@@ -2,4 +2,6 @@ FROM grafana/alloy:latest
 
 COPY alloy-config.alloy /etc/alloy/alloy-config.alloy
 
+CMD ["run", "--server.http.listen-addr=0.0.0.0:12345", "--storage.path=/var/lib/alloy/data", "/etc/alloy/alloy-config.alloy"]
+
 EXPOSE 12345

--- a/.infrastructure/alloy/alloy-config.alloy
+++ b/.infrastructure/alloy/alloy-config.alloy
@@ -1,0 +1,31 @@
+local.file_match "applogs" {
+    path_targets = [{"__path__" = "/tmp/app-logs/app.log"}]
+}
+
+loki.source.file "local_files" {
+    targets    = local.file_match.applogs.targets
+    forward_to = [loki.process.add_new_label.receiver]
+}
+
+loki.process "add_new_label" {
+    stage.logfmt {
+        mapping = {
+            "extracted_level" = "level",
+        }
+    }
+
+    // Add the value of "extracted_level" from the extracted map as a "level" label
+    stage.labels {
+        values = {
+            "level" = "extracted_level",
+        }
+    }
+
+     forward_to = [loki.write.local_loki.receiver]
+}
+
+loki.write "local_loki" {
+    endpoint {
+        url = "http://loki:3100/loki/api/v1/push"
+    }
+}

--- a/.infrastructure/alloy/alloy-config.alloy
+++ b/.infrastructure/alloy/alloy-config.alloy
@@ -1,31 +1,49 @@
-local.file_match "applogs" {
-    path_targets = [{"__path__" = "/tmp/app-logs/app.log"}]
+// From https://github.com/grafana/loki-fundamentals
+
+// This component is responsible for disovering new containers within the docker environment
+discovery.docker "minitwit_alloy" {
+	host = "unix:///var/run/docker.sock"
+	refresh_interval = "5s"
 }
 
-loki.source.file "local_files" {
-    targets    = local.file_match.applogs.targets
-    forward_to = [loki.process.add_new_label.receiver]
+// This component is responsible for relabeling the discovered containers
+discovery.relabel "minitwit_alloy" {
+	targets = []
+
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.*)"
+		target_label  = "container"
+	}
 }
 
-loki.process "add_new_label" {
-    stage.logfmt {
-        mapping = {
-            "extracted_level" = "level",
-        }
-    }
-
-    // Add the value of "extracted_level" from the extracted map as a "level" label
-    stage.labels {
-        values = {
-            "level" = "extracted_level",
-        }
-    }
-
-     forward_to = [loki.write.local_loki.receiver]
+// This component is responsible for collecting logs from the discovered containers
+loki.source.docker "minitwit_alloy" {
+	host             = "unix:///var/run/docker.sock"
+	targets          = discovery.docker.minitwit_alloy.targets
+	forward_to       = [loki.process.minitwit_alloy.receiver]
+	relabel_rules    = discovery.relabel.minitwit_alloy.rules
+	refresh_interval = "5s"
 }
 
-loki.write "local_loki" {
-    endpoint {
-        url = "http://loki:3100/loki/api/v1/push"
+// This component is responsible for processing the logs (In this case adding static labels)
+loki.process "minitwit_alloy" {
+    stage.static_labels {
+    values = {
+      env = "production",
     }
+}
+    forward_to = [loki.write.minitwit_alloy.receiver]
+}
+
+// This component is responsible for writing the logs to Loki
+loki.write "minitwit_alloy" {
+	endpoint {
+		url  = "http://loki:3100/loki/api/v1/push"
+	}
+}
+
+// Enables the ability to view logs in the Alloy UI in realtime
+livedebugging {
+  enabled = true
 }

--- a/.infrastructure/grafana/datasources/datasources.yml
+++ b/.infrastructure/grafana/datasources/datasources.yml
@@ -7,3 +7,10 @@ datasources:
     url: http://${PROMETHEUS_HOST}
     isDefault: true
     editable: false
+  - name: Loki
+    type: loki
+    access: proxy
+    orgId: 1
+    url: 'http://${LOKI_HOST}'
+    limits_config:
+      volume-enabled: true

--- a/.infrastructure/loki/Dockerfile
+++ b/.infrastructure/loki/Dockerfile
@@ -2,4 +2,3 @@ FROM grafana/loki:latest
 
 COPY loki-config.yaml /etc/loki/loki-config.yaml
 
-EXPOSE 3100

--- a/.infrastructure/loki/Dockerfile
+++ b/.infrastructure/loki/Dockerfile
@@ -1,0 +1,5 @@
+FROM grafana/loki:latest
+
+COPY loki-config.yaml /etc/loki/loki-config.yaml
+
+EXPOSE 3100

--- a/.infrastructure/loki/loki-config.yaml
+++ b/.infrastructure/loki/loki-config.yaml
@@ -1,0 +1,63 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: debug
+  grpc_server_max_concurrent_streams: 1000
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+limits_config:
+  metric_aggregation_enabled: true
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+pattern_ingester:
+  enabled: true
+  metric_aggregation:
+    loki_address: localhost:3100
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+frontend:
+  encoding: protobuf
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+#analytics:
+#  reporting_enabled: false

--- a/.infrastructure/loki/loki-config.yaml
+++ b/.infrastructure/loki/loki-config.yaml
@@ -59,5 +59,5 @@ frontend:
 # Refer to the buildReport method to see what goes into a report.
 #
 # If you would like to disable reporting, uncomment the following lines:
-#analytics:
-#  reporting_enabled: false
+analytics:
+  reporting_enabled: false

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -9,7 +9,7 @@ services:
     image: ${DOCKER_USERNAME}/grafana:latest
 
   loki:
-    image: ${DOCKER_USERNAME}/grafana/loki:latest
+    image: ${DOCKER_USERNAME}/loki:latest
 
   alloy:
-    image: ${DOCKER_USERNAME}/grafana/alloy:latest
+    image: ${DOCKER_USERNAME}/alloy:latest

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -7,3 +7,9 @@ services:
 
   grafana:
     image: ${DOCKER_USERNAME}/grafana:latest
+
+  loki:
+    image: ${DOCKER_USERNAME}/grafana/loki:latest
+
+  alloy:
+    image: ${DOCKER_USERNAME}/grafana/alloy:latest

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,8 +7,13 @@ services:
     volumes:
       - sqliteDB:/minitwit/tmp
 
-
   prometheus:
+    build: !reset null
+
+  alloy:
+    build: !reset null
+
+  loki:
     build: !reset null
 
   grafana:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,14 +36,8 @@ services:
     container_name: alloy 
     ports: 
       - 12345:12345
-      - 4317:4317
-      - 4318:4318
     volumes:
-      - ./.infrastructure/alloy/alloy-config.alloy:/etc/alloy/alloy-config.alloy
       - /var/run/docker.sock:/var/run/docker.sock
-    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/alloy-config.alloy
-    depends_on:
-      - app
     networks:
       - main
   
@@ -55,9 +49,6 @@ services:
     container_name: loki
     ports: 
       - "3100:3100"
-    volumes:
-      - ./.infrastructure/loki/loki-config.yaml:/etc/loki/local-config.yaml
-    command: -config.file=/etc/loki/local-config.yaml
     networks:
       - main  
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,8 @@ services:
       context: ./.infrastructure/alloy
     image: alloy_image
     container_name: alloy
-    ports: "12345:12345"
+    ports: 
+      - "12345:12345"
     volumes:
       - ./alloy-config.alloy:/etc/alloy/config.alloy
       - ./logs:/tmp/app-logs/
@@ -51,7 +52,8 @@ services:
       context: ./.infrastructure/loki
     image: loki_image
     container_name: loki
-    ports: "3100:3100"
+    ports: 
+      - "3100:3100"
     networks:
       - main  
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 networks:
-  main:
-    name: minitwit-network
+  main:    
 
 services:
   app:
@@ -17,9 +16,6 @@ services:
     depends_on:
       - grafana
       - prometheus
-      - alloy
-      - loki
-
 
   prometheus:
     build: 
@@ -37,12 +33,17 @@ services:
       dockerfile: ./Dockerfile
       context: ./.infrastructure/alloy
     image: alloy_image
-    container_name: alloy
+    container_name: alloy 
     ports: 
-      - "12345:12345"
+      - 12345:12345
+      - 4317:4317
+      - 4318:4318
     volumes:
-      - ./alloy-config.alloy:/etc/alloy/config.alloy
-      - ./logs:/tmp/app-logs/
+      - ./.infrastructure/alloy/alloy-config.alloy:/etc/alloy/alloy-config.alloy
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/alloy-config.alloy
+    depends_on:
+      - app
     networks:
       - main
   
@@ -54,10 +55,11 @@ services:
     container_name: loki
     ports: 
       - "3100:3100"
+    volumes:
+      - ./.infrastructure/loki/loki-config.yaml:/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/local-config.yaml
     networks:
       - main  
-    volumes:
-      - ./loki-config.yaml:/etc/loki/loki-config.yaml
 
   grafana:
     build: 
@@ -69,11 +71,11 @@ services:
       - "3000:3000"  
     environment:
       - PROMETHEUS_HOST=prometheus:9090
+      - LOKI_HOST=loki:3100
     networks:
       - main
     volumes:
       - grafana-storage:/var/lib/grafana
-
 
 volumes:
   sqliteDB:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     depends_on:
       - grafana
       - prometheus
+      - alloy
+      - loki
 
 
   prometheus:
@@ -30,6 +32,30 @@ services:
     networks:
       - main
 
+  alloy:
+    build: 
+      dockerfile: ./Dockerfile
+      context: ./.infrastructure/alloy
+    image: alloy_image
+    container_name: alloy
+    ports: "12345:12345"
+    volumes:
+      - ./alloy-config.alloy:/etc/alloy/config.alloy
+      - ./logs:/tmp/app-logs/
+    networks:
+      - main
+  
+  loki:
+    build: 
+      dockerfile: ./Dockerfile
+      context: ./.infrastructure/loki
+    image: loki_image
+    container_name: loki
+    ports: "3100:3100"
+    networks:
+      - main  
+    volumes:
+      - ./loki-config.yaml:/etc/loki/loki-config.yaml
 
   grafana:
     build: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,6 @@ services:
       context: ./.infrastructure/alloy
     image: alloy_image
     container_name: alloy 
-    ports: 
-      - 12345:12345
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:
@@ -47,8 +45,6 @@ services:
       context: ./.infrastructure/loki
     image: loki_image
     container_name: loki
-    ports: 
-      - "3100:3100"
     networks:
       - main  
 


### PR DESCRIPTION
**Purpose**

* Add logging

**Changes**
* Adds loki and alloy folders to `.infrastructure` (which correspond to Grafana Loki, which is our logging stack, and Grafana Alloy, which gathers data and sends data to Loki.
* Significantly updates the `docker-compose.yml` file and the other docker-compose files to setup loki and alloy as well.
* Update `grafana/datasources/datasources.yml` so loki is included.

* The stack is initialized with:
```
docker compose up -d
```
You access the loki logs by opening Grafana on port 3000, logging in, and opening  "Drilldown" -> "Logs" . 

**Further Work**

* As seen in section [Basics of how to use Kibana](https://github.com/itu-devops/itu-minitwit-logging?tab=readme-ov-file#basics-of-how-to-use-kibana) you can (or should) set up different data views. 
I suggest we start with one that has 'message' information, just because it shows information that is easily mapped to user actions.

**Task Relations:**

* Closes #108 

![image](https://github.com/user-attachments/assets/be1d87b3-edc9-4a0d-9f44-4cdfcf5eafef)

