### PR TITLE
Fix : Remove redundant error messages

### DIFF
--- a/src/datalayer/repository.go
+++ b/src/datalayer/repository.go
@@ -240,10 +240,11 @@ func (r *Repository[T]) queryRow(ctx context.Context, field string, values ...an
 
 	err := row.Scan(fields...)
 	if err != nil {
-        log.Printf("❌ SQL ERROR: Query: %s | Values: %v | Err: %v", query, values, err)
 		if errors.Is(err, sql.ErrNoRows) {
+			log.Printf("⚠️ Warning: Query: %s | Values: %v | Err: %v", query, values, err)
 			return nil, ErrRecordNotFound
 		}
+		log.Printf("❌ SQL ERROR: Query: %s | Values: %v | Err: %v", query, values, err)
 		return nil, err
 	}
 	return &entity, nil


### PR DESCRIPTION
Inspecting our app logs revealed a lot of "Error" messages as a result of SELECT * queries not returning results. As mentioned here http://go-database-sql.org/errors.html, ErrNoRows are not technically errors.

![image](https://github.com/user-attachments/assets/3546c8f9-ccba-4249-a7ed-2df6127fb04f)
