### PR TITLE
Fix : Repository.CountRowsWhenGroupedByFieldInRange used legacy query formatting

### DIFF
--- a/src/datalayer/repository.go
+++ b/src/datalayer/repository.go
@@ -196,7 +196,7 @@ func (r *Repository[T]) CountRowsWhenGroupedByFieldInRange(ctx context.Context, 
             FROM %s
             GROUP BY %s
         ) sub
-        WHERE amount BETWEEN ? AND ?;
+        WHERE amount BETWEEN $1 AND $2;
     `, field, r.tableName, field)
     
     row := r.db.QueryRowContext(ctx, query, lower, upper)


### PR DESCRIPTION
It must have slipped past me during database, but there is a method which does not function, due to PostgreSQL using indexed values instead of relying on input-sequence with ?.