### PR TITLE
Documentation for Database Error

### DIFF
--- a/docs/database-migration/restart-error/sequence-fix.sh
+++ b/docs/database-migration/restart-error/sequence-fix.sh
@@ -1,0 +1,13 @@
+
+
+# Get the current serial sequence of message at message_id
+SQL_TEXT="SELECT pg_get_serial_sequence('message', 'message_id');"
+echo $SQL_TEXT | ssh root@164.90.227.119 "docker exec -i database psql -U admin -d minitwit"
+
+# Inspect the serial sequence of message at message_id
+SQL_TEXT="SELECT s.* FROM message_message_id_seq s;"
+echo $SQL_TEXT | ssh root@164.90.227.119 "docker exec -i database psql -U admin -d minitwit"
+
+# Set the value of the current serial sequence of message at message_id to the current highest message_id +1
+SQL_TEXT="SELECT setval(pg_get_serial_sequence('message', 'message_id'), MAX(message_id)+1) FROM message;"
+echo $SQL_TEXT | ssh root@164.90.227.119 "docker exec -i database psql -U admin -d minitwit"

--- a/docs/database-migration/restart-error/too-many-client.sh
+++ b/docs/database-migration/restart-error/too-many-client.sh
@@ -1,0 +1,15 @@
+# To see the amount of current connections:
+SQL_TEXT="SELECT COUNT(*) FROM pg_stat_activity;"
+echo $SQL_TEXT | ssh root@164.90.227.119 "docker exec -i database psql -U admin -d minitwit"
+
+# To see the details of the current connections:
+SQL_TEXT="SELECT sa.* FROM pg_stat_activity sa;"
+echo $SQL_TEXT | ssh root@164.90.227.119 "docker exec -i database psql -U admin -d minitwit"
+
+# To see the current maximum connections:
+SQL_TEXT="SHOW max_connections;"
+echo $SQL_TEXT | ssh root@164.90.227.119 "docker exec -i database psql -U admin -d minitwit"
+
+# To see the maximum allowed value for the "current maximum connections"-setting:
+SQL_TEXT="SELECT min_val, max_val FROM pg_settings WHERE NAME='max_connections';"
+echo $SQL_TEXT | ssh root@164.90.227.119 "docker exec -i database psql -U admin -d minitwit"


### PR DESCRIPTION
This PR contains 2 documentation files, for fixing of issue #123 .

There were 2 general issues:
- Database container would crash due to "FATAL: sorry, too many clients already"-error
     - Our issue seems to have been that the program used an amount of connections, at times, which qwew greater than the configured maximum amount of connections. I have therefore set the maximum amount of connections from 100 to 1000. 100 is the default, and 262143 is the maximum allowed configured number for maximum amount of connections)
     - [Source](https://stackoverflow.com/questions/2757549/org-postgresql-util-psqlexception-fatal-sorry-too-many-clients-already)

- After restarting the database container, the sequence variables used for incrementing message_id and user_id, were set to a number far lower than the current next_val for each column. 
   - To fix this, I resat the values to the maximum id + 1


closes #123 