### PR TITLE
fix: remove `DISTINCT` from `GetFiltered` method as all tables have  …

### DIFF
--- a/src/datalayer/repository.go
+++ b/src/datalayer/repository.go
@@ -147,7 +147,7 @@ func (r *Repository[T]) GetFiltered(ctx context.Context, conditions map[string]a
         }
     }
 
-    query := fmt.Sprintf("SELECT DISTINCT * FROM %s", r.tableName)
+    query := fmt.Sprintf("SELECT * FROM %s", r.tableName)
     if len(whereClauses) > 0 {
         query += " WHERE " + strings.Join(whereClauses, " AND ")
     }


### PR DESCRIPTION
…a primary-key column and hence is redundant