### PR TITLE
Fix for Workflows failing due to version errors

### DIFF
--- a/.github/workflows/continous-development.yml
+++ b/.github/workflows/continous-development.yml
@@ -16,18 +16,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@main
 
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@master
 
     - name: Build Docker Container
       run: |
         docker compose up -d
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@main
       with:
         python-version: '3.x'
 
@@ -54,19 +54,19 @@ jobs:
     needs: tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@main
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@master
         with:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@master
 
       - name: Build and push images
-        uses: docker/bake-action@v3
+        uses: docker/bake-action@master
         env:
           DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
         with:
@@ -87,7 +87,7 @@ jobs:
     needs: tests
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@main
         with:
           fetch-depth: 0 # Get all tags and history 
 
@@ -151,7 +151,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@main
 
       - name: Configure SSH
         run: |

--- a/.github/workflows/continous-development.yml
+++ b/.github/workflows/continous-development.yml
@@ -16,18 +16,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout
+      uses: actions/checkout@main
 
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action
+      uses: docker/setup-buildx-action@master
 
     - name: Build Docker Container
       run: |
         docker compose up -d
 
     - name: Set up Python
-      uses: actions/setup-python
+      uses: actions/setup-python@main
       with:
         python-version: '3.x'
 
@@ -54,19 +54,19 @@ jobs:
     needs: tests
     steps:
       - name: Checkout
-        uses: actions/checkout
+        uses: actions/checkout@main
 
       - name: Login to Docker Hub
-        uses: docker/login-action
+        uses: docker/login-action@master
         with:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action
+        uses: docker/setup-buildx-action@master
 
       - name: Build and push images
-        uses: docker/bake-action
+        uses: docker/bake-action@master
         env:
           DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
         with:
@@ -87,7 +87,7 @@ jobs:
     needs: tests
 
     steps:
-      - uses: actions/checkout
+      - uses: actions/checkout@main
         with:
           fetch-depth: 0 # Get all tags and history 
 
@@ -151,7 +151,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout
+        uses: actions/checkout@main
 
       - name: Configure SSH
         run: |
@@ -162,7 +162,7 @@ jobs:
           SSH_KEY: ${{ secrets.SSH_KEY }}
 
       - name: copy files to target server via scp
-        uses: appleboy/scp-action
+        uses: appleboy/scp-action@master
         with:
           host: ${{ vars.SSH_HOST }}
           username: ${{ vars.SSH_USER }}
@@ -177,7 +177,7 @@ jobs:
           DB_HOST: ${{ vars.DB_HOST }}
           DB_PORT: ${{ vars.DB_PORT }}
           DB_NAME: ${{ vars.DB_NAME }}
-        uses: appleboy/ssh-action
+        uses: appleboy/ssh-action@master
         with:
           host: ${{ vars.SSH_HOST }}
           username: ${{ vars.SSH_USER }}

--- a/.github/workflows/continous-development.yml
+++ b/.github/workflows/continous-development.yml
@@ -16,18 +16,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@main
+      uses: actions/checkout
 
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@master
+      uses: docker/setup-buildx-action
 
     - name: Build Docker Container
       run: |
         docker compose up -d
 
     - name: Set up Python
-      uses: actions/setup-python@main
+      uses: actions/setup-python
       with:
         python-version: '3.x'
 
@@ -54,19 +54,19 @@ jobs:
     needs: tests
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout
 
       - name: Login to Docker Hub
-        uses: docker/login-action@master
+        uses: docker/login-action
         with:
           username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action
 
       - name: Build and push images
-        uses: docker/bake-action@master
+        uses: docker/bake-action
         env:
           DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
         with:
@@ -87,7 +87,7 @@ jobs:
     needs: tests
 
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout
         with:
           fetch-depth: 0 # Get all tags and history 
 
@@ -151,7 +151,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout
 
       - name: Configure SSH
         run: |
@@ -162,7 +162,7 @@ jobs:
           SSH_KEY: ${{ secrets.SSH_KEY }}
 
       - name: copy files to target server via scp
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action
         with:
           host: ${{ vars.SSH_HOST }}
           username: ${{ vars.SSH_USER }}
@@ -177,7 +177,7 @@ jobs:
           DB_HOST: ${{ vars.DB_HOST }}
           DB_PORT: ${{ vars.DB_PORT }}
           DB_NAME: ${{ vars.DB_NAME }}
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action
         with:
           host: ${{ vars.SSH_HOST }}
           username: ${{ vars.SSH_USER }}

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -20,18 +20,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout
+      uses: actions/checkout@main
 
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action
+      uses: docker/setup-buildx-action@master
 
     - name: Build Docker Container
       run: |
         docker compose up -d
 
     - name: Set up Python
-      uses: actions/setup-python
+      uses: actions/setup-python@main
       with:
         python-version: '3.x'
 
@@ -42,7 +42,7 @@ jobs:
 
     - name: SonarCloud Scan
       if: github.event_name == 'pull_request'
-      uses: SonarSource/sonarcloud-github-action
+      uses: SonarSource/sonarcloud-github-action@master
       with:
         projectBaseDir: .
         args: >

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -20,18 +20,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@main
+      uses: actions/checkout
 
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@master
+      uses: docker/setup-buildx-action
 
     - name: Build Docker Container
       run: |
         docker compose up -d
 
     - name: Set up Python
-      uses: actions/setup-python@main
+      uses: actions/setup-python
       with:
         python-version: '3.x'
 
@@ -42,7 +42,7 @@ jobs:
 
     - name: SonarCloud Scan
       if: github.event_name == 'pull_request'
-      uses: SonarSource/sonarcloud-github-action@master
+      uses: SonarSource/sonarcloud-github-action
       with:
         projectBaseDir: .
         args: >

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -20,18 +20,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@main
 
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@master
 
     - name: Build Docker Container
       run: |
         docker compose up -d
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@main
       with:
         python-version: '3.x'
 
@@ -42,7 +42,7 @@ jobs:
 
     - name: SonarCloud Scan
       if: github.event_name == 'pull_request'
-      uses: SonarSource/sonarcloud-github-action@v2
+      uses: SonarSource/sonarcloud-github-action@master
       with:
         projectBaseDir: .
         args: >

--- a/.github/workflows/pull-request-tests.yml
+++ b/.github/workflows/pull-request-tests.yml
@@ -12,7 +12,6 @@ on:
       - main
 
   workflow_dispatch:
-    manual: true
 
 jobs:
   tests:

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -14,17 +14,17 @@
 
       steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@main
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@master
 
       - name: Build Docker Container
         run: |
           docker compose up -d
   
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@main
         with:
           python-version: '3.x'
 
@@ -50,7 +50,7 @@
 
       steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@main
 
         - name: Copy docker-compose files to server
           uses: appleboy/scp-action@master
@@ -62,16 +62,16 @@
             target: "~/.deploy/${{ github.event.repository.name }}/"
 
         - name: Login to Docker Hub
-          uses: docker/login-action@v3
+          uses: docker/login-action@master
           with:
             username: ${{ vars.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
 
         - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3
+          uses: docker/setup-buildx-action@master
 
         - name: Build and Push Docker image
-          uses: docker/bake-action@v3
+          uses: docker/bake-action@master
           env:
             DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
           with:

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -14,17 +14,17 @@
 
       steps:
       - name: Checkout
-        uses: actions/checkout
+        uses: actions/checkout@main
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action
+        uses: docker/setup-buildx-action@master
 
       - name: Build Docker Container
         run: |
           docker compose up -d
   
       - name: Set up Python
-        uses: actions/setup-python
+        uses: actions/setup-python@main
         with:
           python-version: '3.x'
 
@@ -50,10 +50,10 @@
 
       steps:
         - name: Checkout
-          uses: actions/checkout
+          uses: actions/checkout@main
 
         - name: Copy docker-compose files to server
-          uses: appleboy/scp-action
+          uses: appleboy/scp-action@master
           with:
             host: ${{ vars.TEST_ENV_SSH_HOST }}
             username: ${{ vars.SSH_USER }}
@@ -62,16 +62,16 @@
             target: "~/.deploy/${{ github.event.repository.name }}/"
 
         - name: Login to Docker Hub
-          uses: docker/login-action
+          uses: docker/login-action@master
           with:
             username: ${{ vars.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
 
         - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action
+          uses: docker/setup-buildx-action@master
 
         - name: Build and Push Docker image
-          uses: docker/bake-action
+          uses: docker/bake-action@master
           env:
             DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
           with:
@@ -106,7 +106,7 @@
             DB_HOST: ${{ vars.TEST_ENV_DB_HOST }}
             DB_PORT: ${{ vars.DB_PORT }}
             DB_NAME: ${{ vars.DB_NAME }}
-          uses: appleboy/ssh-action
+          uses: appleboy/ssh-action@master
           with:
             host: ${{ vars.TEST_ENV_SSH_HOST }}
             username: ${{ vars.SSH_USER }}
@@ -126,7 +126,7 @@
                 up -d --pull always
 
         - name: Check running Docker containers
-          uses: appleboy/ssh-action
+          uses: appleboy/ssh-action@master
           with:
             host: ${{ vars.TEST_ENV_SSH_HOST }}
             username: ${{ vars.SSH_USER }}

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -14,17 +14,17 @@
 
       steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action
 
       - name: Build Docker Container
         run: |
           docker compose up -d
   
       - name: Set up Python
-        uses: actions/setup-python@main
+        uses: actions/setup-python
         with:
           python-version: '3.x'
 
@@ -50,10 +50,10 @@
 
       steps:
         - name: Checkout
-          uses: actions/checkout@main
+          uses: actions/checkout
 
         - name: Copy docker-compose files to server
-          uses: appleboy/scp-action@master
+          uses: appleboy/scp-action
           with:
             host: ${{ vars.TEST_ENV_SSH_HOST }}
             username: ${{ vars.SSH_USER }}
@@ -62,16 +62,16 @@
             target: "~/.deploy/${{ github.event.repository.name }}/"
 
         - name: Login to Docker Hub
-          uses: docker/login-action@master
+          uses: docker/login-action
           with:
             username: ${{ vars.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
 
         - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@master
+          uses: docker/setup-buildx-action
 
         - name: Build and Push Docker image
-          uses: docker/bake-action@master
+          uses: docker/bake-action
           env:
             DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
           with:
@@ -106,7 +106,7 @@
             DB_HOST: ${{ vars.TEST_ENV_DB_HOST }}
             DB_PORT: ${{ vars.DB_PORT }}
             DB_NAME: ${{ vars.DB_NAME }}
-          uses: appleboy/ssh-action@master
+          uses: appleboy/ssh-action
           with:
             host: ${{ vars.TEST_ENV_SSH_HOST }}
             username: ${{ vars.SSH_USER }}
@@ -126,7 +126,7 @@
                 up -d --pull always
 
         - name: Check running Docker containers
-          uses: appleboy/ssh-action@master
+          uses: appleboy/ssh-action
           with:
             host: ${{ vars.TEST_ENV_SSH_HOST }}
             username: ${{ vars.SSH_USER }}


### PR DESCRIPTION
This is a fix to accommodate the following, and future similar, errors:
![image](https://github.com/user-attachments/assets/1ab08a2b-06dd-4c98-9305-cb727087ff7d)


Instead of using specific versions for each "uses" in our github-workflows, this PR makes all the uses instead use whatever is on their main/master branch. This of course trusts that what is on their main/master-branch works. However, it is way more future proof than the alternative.

The `@___` part of `uses:` seems to be necessary. I tried removing them and this made the workflows unreadable for GitHub.
![image](https://github.com/user-attachments/assets/9dd45ded-c22a-4548-a79b-bb71290af161)
