### PR TITLE
Task 152 security patch csrf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY ./src/routes ./src/routes
 COPY ./src/template_rendering ./src/template_rendering
 COPY ./src/snapshots ./src/snapshots
 COPY ./src/utils ./src/utils
+COPY ./src/middleware ./src/middleware
 
 RUN go build -o minitwit ./src/main.go
 

--- a/refactored_minitwit_tests.py
+++ b/refactored_minitwit_tests.py
@@ -9,6 +9,7 @@
     :copyright: (c) 2010 by Armin Ronacher.
     :license: BSD, see LICENSE for more details.
 """
+import re
 import requests
 
 

--- a/refactored_minitwit_tests.py
+++ b/refactored_minitwit_tests.py
@@ -17,6 +17,15 @@ import requests
 # otherwise use the database that you got previously
 BASE_URL = "http://localhost:8000"
 
+def get_csrf_token(session: requests.Session, path: str) -> str:
+    """Fetch the form at `path` and extract the CSRF token from the hidden input."""
+    r = session.get(f"{BASE_URL}{path}")
+    # look for: <input type="hidden" name="_csrf" value="...">
+    m = re.search(r'name="_csrf"\s+value="([^"]+)"', r.text)
+    if not m:
+        raise RuntimeError(f"Unable to find CSRF token on {path}")
+    return m.group(1)
+
 def register(username, password, password2=None, email=None):
     """Helper function to register a user"""
     if password2 is None:

--- a/refactored_minitwit_tests.py
+++ b/refactored_minitwit_tests.py
@@ -70,10 +70,14 @@ def logout(http_session):
 
 def add_message(http_session, text):
     """Records a message"""
-    r = http_session.post(f'{BASE_URL}/add_message', data={'text': text},
-                                allow_redirects=True)
+    token = get_csrf_token(http_session, "/")
+    data = {
+        "_csrf": token,
+        "text":  text,
+    }
+    r = http_session.post(f"{BASE_URL}/add_message", data=data, allow_redirects=True)
     if text:
-        assert 'Your message was recorded' in r.text
+        assert "Your message was recorded" in r.text
     return r
 
 # testing functions

--- a/refactored_minitwit_tests.py
+++ b/refactored_minitwit_tests.py
@@ -32,12 +32,19 @@ def register(username, password, password2=None, email=None):
         password2 = password
     if email is None:
         email = username + '@example.com'
-    return requests.post(f'{BASE_URL}/register', data={
-        'username':     username,
-        'password':     password,
-        'password2':    password2,
-        'email':        email,
-    }, allow_redirects=True)
+
+    session = requests.Session()
+    token = get_csrf_token(session, "/register")
+
+    data = {
+        "_csrf":    token,
+        "username": username,
+        "password": password,
+        "password2": password2,
+        "email":     email,
+    }
+    r = session.post(f"{BASE_URL}/register", data=data, allow_redirects=True)
+    return r
 
 def login(username, password):
     """Helper function to login"""

--- a/refactored_minitwit_tests.py
+++ b/refactored_minitwit_tests.py
@@ -48,12 +48,16 @@ def register(username, password, password2=None, email=None):
 
 def login(username, password):
     """Helper function to login"""
-    http_session = requests.Session()
-    r = http_session.post(f'{BASE_URL}/login', data={
-        'username': username,
-        'password': password
-    }, allow_redirects=True)
-    return r, http_session
+    session = requests.Session()
+    token = get_csrf_token(session, "/login")
+
+    data = {
+        "_csrf":    token,
+        "username": username,
+        "password": password,
+    }
+    r = session.post(f"{BASE_URL}/login", data=data, allow_redirects=True)
+    return r, session
 
 def register_and_login(username, password):
     """Registers and logs in in one go"""

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -163,19 +163,25 @@ def test_get_latest_msgs():
 
 
 def test_register_b():
+    session = make_auth_session()
+    csrf = session.cookies['csrf_token']
+
     username = 'b'
     email = 'b@b.b'
     pwd = 'b'
     data = {'username': username, 'email': email, 'pwd': pwd}
     params = {'latest': 5}
-    response = requests.post(f'{BASE_URL}/register', data=json.dumps(data),
-                             headers=HEADERS, params=params)
-    assert response.ok
-    # TODO: add another assertion that it is really there
+    r = session.post(
+        f'{BASE_URL}/register',
+        params=params,
+        data=json.dumps(data),
+        headers={**HEADERS, 'X-CSRF-Token': csrf}
+    )
+    assert r.ok
 
     # verify that latest was updated
-    response = requests.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert response.json()['latest'] == 5
+    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert r.json()['latest'] == 5
 
 
 def test_register_c():

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -103,17 +103,24 @@ def test_register():
 
 
 def test_create_msg():
+    session = make_auth_session()
+    csrf = session.cookies['csrf_token']
+
     username = 'a'
     data = {'content': 'Blub!'}
     url = f'{BASE_URL}/msgs/{username}'
     params = {'latest': 2}
-    response = requests.post(url, data=json.dumps(data),
-                             headers=HEADERS, params=params)
-    assert response.ok
+    r = session.post(
+        url,
+        params=params,
+        data=json.dumps(data),
+        headers={**HEADERS, 'X-CSRF-Token': csrf}
+    )
+    assert r.ok
 
     # verify that latest was updated
-    response = requests.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert response.json()['latest'] == 2
+    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert r.json()['latest'] == 2
 
 
 def test_get_latest_user_msgs():

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -37,7 +37,7 @@ def get_csrf_token(session: requests.Session, path: str) -> str:
     Issue a GET to `path` to pick up the `csrf_token` cookie,
     then return its value.
     """
-    r = session.get(BASE_URL + path)
+    _ = session.get(BASE_URL + path)
     # csrf_token is set as an HttpOnly cookie by Echo's middleware
     token = session.cookies.get('csrf_token')
     if not token:
@@ -65,18 +65,18 @@ def test_latest():
     url = f"{BASE_URL}/register"
     data = {'username': 'test', 'email': 'test@test', 'pwd': 'foo'}
     params = {'latest': 1337}
-    r = session.post(
+    response = session.post(
         url,
         params=params,
         data=json.dumps(data),
         headers={**HEADERS, 'X-CSRF-Token': csrf}
     )
-    assert r.ok
+    assert response.ok
 
     # verify that latest was updated
-    r = session.get(f"{BASE_URL}/latest", headers=HEADERS)
-    assert r.ok
-    assert r.json()['latest'] == 1337
+    response = session.get(f"{BASE_URL}/latest", headers=HEADERS)
+    assert response.ok
+    assert response.json()['latest'] == 1337
 
 
 def test_register():
@@ -88,17 +88,17 @@ def test_register():
     pwd = 'a'
     data = {'username': username, 'email': email, 'pwd': pwd}
     params = {'latest': 1}
-    r = session.post(
+    response = session.post(
         f'{BASE_URL}/register',
         params=params,
         data=json.dumps(data),
         headers={**HEADERS, 'X-CSRF-Token': csrf}
     )
-    assert r.ok
+    assert response.ok
 
     # verify that latest was updated
-    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert r.json()['latest'] == 1
+    response = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert response.json()['latest'] == 1
 
 
 def test_create_msg():
@@ -109,17 +109,17 @@ def test_create_msg():
     data = {'content': 'Blub!'}
     url = f'{BASE_URL}/msgs/{username}'
     params = {'latest': 2}
-    r = session.post(
+    response = session.post(
         url,
         params=params,
         data=json.dumps(data),
         headers={**HEADERS, 'X-CSRF-Token': csrf}
     )
-    assert r.ok
+    assert response.ok
 
     # verify that latest was updated
-    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert r.json()['latest'] == 2
+    response = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert response.json()['latest'] == 2
 
 
 def test_get_latest_user_msgs():
@@ -128,18 +128,18 @@ def test_get_latest_user_msgs():
 
     query = {'no': 20, 'latest': 3}
     url = f'{BASE_URL}/msgs/{username}'
-    r = session.get(url, headers=HEADERS, params=query)
-    assert r.status_code == 200
+    response = session.get(url, headers=HEADERS, params=query)
+    assert response.status_code == 200
 
     found = any(
         msg['content'] == 'Blub!' and msg['user'] == username
-        for msg in r.json()
+        for msg in response.json()
     )
     assert found
 
     # verify that latest was updated
-    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert r.json()['latest'] == 3
+    response = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert response.json()['latest'] == 3
 
 
 def test_get_latest_msgs():
@@ -147,18 +147,18 @@ def test_get_latest_msgs():
     username = 'a'
     query = {'no': 20, 'latest': 4}
     url = f'{BASE_URL}/msgs'
-    r = session.get(url, headers=HEADERS, params=query)
-    assert r.status_code == 200
+    response = session.get(url, headers=HEADERS, params=query)
+    assert response.status_code == 200
 
     found = any(
         msg['content'] == 'Blub!' and msg['user'] == username
-        for msg in r.json()
+        for msg in response.json()
     )
     assert found
 
     # verify that latest was updated
-    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert r.json()['latest'] == 4
+    response = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert response.json()['latest'] == 4
 
 
 def test_register_b():
@@ -170,17 +170,17 @@ def test_register_b():
     pwd = 'b'
     data = {'username': username, 'email': email, 'pwd': pwd}
     params = {'latest': 5}
-    r = session.post(
+    response = session.post(
         f'{BASE_URL}/register',
         params=params,
         data=json.dumps(data),
         headers={**HEADERS, 'X-CSRF-Token': csrf}
     )
-    assert r.ok
+    assert response.ok
 
     # verify that latest was updated
-    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert r.json()['latest'] == 5
+    response = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert response.json()['latest'] == 5
 
 
 def test_register_c():
@@ -192,17 +192,17 @@ def test_register_c():
     pwd = 'c'
     data = {'username': username, 'email': email, 'pwd': pwd}
     params = {'latest': 6}
-    r = session.post(
+    response = session.post(
         f'{BASE_URL}/register',
         params=params,
         data=json.dumps(data),
         headers={**HEADERS, 'X-CSRF-Token': csrf}
     )
-    assert r.ok
+    assert response.ok
 
     # verify that latest was updated
-    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert r.json()['latest'] == 6
+    response = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert response.json()['latest'] == 6
 
 
 def test_follow_user():
@@ -213,35 +213,35 @@ def test_follow_user():
     url = f'{BASE_URL}/fllws/{username}'
     data = {'follow': 'b'}
     params = {'latest': 7}
-    r = session.post(
+    response = session.post(
         url,
         params=params,
         data=json.dumps(data),
         headers={**HEADERS, 'X-CSRF-Token': csrf}
     )
-    assert r.ok
+    assert response.ok
 
     data = {'follow': 'c'}
     params = {'latest': 8}
-    r = session.post(
+    response = session.post(
         url,
         params=params,
         data=json.dumps(data),
         headers={**HEADERS, 'X-CSRF-Token': csrf}
     )
-    assert r.ok
+    assert response.ok
 
     query = {'no': 20, 'latest': 9}
-    r = session.get(url, headers=HEADERS, params=query)
-    assert r.ok
+    response = session.get(url, headers=HEADERS, params=query)
+    assert response.ok
 
-    json_data = r.json()
+    json_data = response.json()
     assert "b" in json_data["follows"]
     assert "c" in json_data["follows"]
 
     # verify that latest was updated
-    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert r.json()['latest'] == 9
+    response = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert response.json()['latest'] == 9
 
 
 def test_a_unfollows_b():
@@ -254,20 +254,20 @@ def test_a_unfollows_b():
     #  first send unfollow command
     data = {'unfollow': 'b'}
     params = {'latest': 10}
-    r = session.post(
+    response = session.post(
         url,
         params=params,
         data=json.dumps(data),
         headers={**HEADERS, 'X-CSRF-Token': csrf}
     )
-    assert r.ok
+    assert response.ok
 
     # then verify that b is no longer in follows list
     query = {'no': 20, 'latest': 11}
-    r = session.get(url, params=query, headers=HEADERS)
-    assert r.ok
-    assert 'b' not in r.json()['follows']
+    response = session.get(url, params=query, headers=HEADERS)
+    assert response.ok
+    assert 'b' not in response.json()['follows']
 
     # verify that latest was updated
-    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert r.json()['latest'] == 11
+    response = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert response.json()['latest'] == 11

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -1,4 +1,3 @@
-import os
 import json
 import sqlite3
 import requests

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -144,22 +144,22 @@ def test_get_latest_user_msgs():
 
 
 def test_get_latest_msgs():
+    session = make_auth_session()
     username = 'a'
     query = {'no': 20, 'latest': 4}
     url = f'{BASE_URL}/msgs'
-    response = requests.get(url, headers=HEADERS, params=query)
-    assert response.status_code == 200
+    r = session.get(url, headers=HEADERS, params=query)
+    assert r.status_code == 200
 
-    got_it_earlier = False
-    for msg in response.json():
-        if msg['content'] == 'Blub!' and msg['user'] == username:
-            got_it_earlier = True
-
-    assert got_it_earlier
+    found = any(
+        msg['content'] == 'Blub!' and msg['user'] == username
+        for msg in r.json()
+    )
+    assert found
 
     # verify that latest was updated
-    response = requests.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert response.json()['latest'] == 4
+    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert r.json()['latest'] == 4
 
 
 def test_register_b():

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -246,22 +246,29 @@ def test_follow_user():
 
 
 def test_a_unfollows_b():
+    session = make_auth_session()
+    csrf = session.cookies['csrf_token']
+
     username = 'a'
     url = f'{BASE_URL}/fllws/{username}'
 
     #  first send unfollow command
     data = {'unfollow': 'b'}
     params = {'latest': 10}
-    response = requests.post(url, data=json.dumps(data),
-                             headers=HEADERS, params=params)
-    assert response.ok
+    r = session.post(
+        url,
+        params=params,
+        data=json.dumps(data),
+        headers={**HEADERS, 'X-CSRF-Token': csrf}
+    )
+    assert r.ok
 
     # then verify that b is no longer in follows list
     query = {'no': 20, 'latest': 11}
-    response = requests.get(url, params=query, headers=HEADERS)
-    assert response.ok
-    assert 'b' not in response.json()['follows']
+    r = session.get(url, params=query, headers=HEADERS)
+    assert r.ok
+    assert 'b' not in r.json()['follows']
 
     # verify that latest was updated
-    response = requests.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert response.json()['latest'] == 11
+    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert r.json()['latest'] == 11

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -59,19 +59,25 @@ def make_auth_session() -> requests.Session:
 
 
 def test_latest():
+    session = make_auth_session()
+    csrf = session.cookies['csrf_token']
+
     # post something to update LATEST
     url = f"{BASE_URL}/register"
     data = {'username': 'test', 'email': 'test@test', 'pwd': 'foo'}
     params = {'latest': 1337}
-    response = requests.post(url, data=json.dumps(data),
-                             params=params, headers=HEADERS)
-    assert response.ok
+    r = session.post(
+        url,
+        params=params,
+        data=json.dumps(data),
+        headers={**HEADERS, 'X-CSRF-Token': csrf}
+    )
+    assert r.ok
 
     # verify that latest was updated
-    url = f'{BASE_URL}/latest'
-    response = requests.get(url, headers=HEADERS)
-    assert response.ok
-    assert response.json()['latest'] == 1337
+    r = session.get(f"{BASE_URL}/latest", headers=HEADERS)
+    assert r.ok
+    assert r.json()['latest'] == 1337
 
 
 def test_register():

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -1,6 +1,5 @@
 import os
 import json
-import base64
 import sqlite3
 import requests
 from pathlib import Path

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -33,9 +33,17 @@ def init_db():
         db.commit()
 
 
-# Empty the database and initialize the schema again
-#Path(DATABASE).unlink()
-#init_db()
+def get_csrf_token(session: requests.Session, path: str) -> str:
+    """
+    Issue a GET to `path` to pick up the `csrf_token` cookie,
+    then return its value.
+    """
+    r = session.get(BASE_URL + path)
+    # csrf_token is set as an HttpOnly cookie by Echo's middleware
+    token = session.cookies.get('csrf_token')
+    if not token:
+        raise RuntimeError(f"No csrf_token cookie after GET {path}")
+    return token
 
 
 def test_latest():

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -185,18 +185,25 @@ def test_register_b():
 
 
 def test_register_c():
+    session = make_auth_session()
+    csrf = session.cookies['csrf_token']
+
     username = 'c'
     email = 'c@c.c'
     pwd = 'c'
     data = {'username': username, 'email': email, 'pwd': pwd}
     params = {'latest': 6}
-    response = requests.post(f'{BASE_URL}/register', data=json.dumps(data),
-                             headers=HEADERS, params=params)
-    assert response.ok
+    r = session.post(
+        f'{BASE_URL}/register',
+        params=params,
+        data=json.dumps(data),
+        headers={**HEADERS, 'X-CSRF-Token': csrf}
+    )
+    assert r.ok
 
     # verify that latest was updated
-    response = requests.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert response.json()['latest'] == 6
+    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert r.json()['latest'] == 6
 
 
 def test_follow_user():

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -81,19 +81,25 @@ def test_latest():
 
 
 def test_register():
+    session = make_auth_session()
+    csrf = session.cookies['csrf_token']
+
     username = 'a'
     email = 'a@a.a'
     pwd = 'a'
     data = {'username': username, 'email': email, 'pwd': pwd}
     params = {'latest': 1}
-    response = requests.post(f'{BASE_URL}/register',
-                             data=json.dumps(data), headers=HEADERS, params=params)
-    assert response.ok
-    # TODO: add another assertion that it is really there
+    r = session.post(
+        f'{BASE_URL}/register',
+        params=params,
+        data=json.dumps(data),
+        headers={**HEADERS, 'X-CSRF-Token': csrf}
+    )
+    assert r.ok
 
     # verify that latest was updated
-    response = requests.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert response.json()['latest'] == 1
+    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert r.json()['latest'] == 1
 
 
 def test_create_msg():

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -10,11 +10,10 @@ BASE_URL = 'http://127.0.0.1:8000'
 DATABASE = "/tmp/minitwit.db"
 USERNAME = 'simulator'
 PWD = 'super_safe!'
-CREDENTIALS = ':'.join([USERNAME, PWD]).encode('ascii')
-ENCODED_CREDENTIALS = base64.b64encode(CREDENTIALS).decode()
-HEADERS = {'Connection': 'close',
-           'Content-Type': 'application/json',
-           f'Authorization': f'Basic {ENCODED_CREDENTIALS}'}
+HEADERS = {
+    'Connection': 'close',
+    'Content-Type': 'application/json',
+}
 
 
 def init_db():

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -46,6 +46,18 @@ def get_csrf_token(session: requests.Session, path: str) -> str:
     return token
 
 
+def make_auth_session() -> requests.Session:
+    """
+    Returns a Session pre-configured with BasicAuth and
+    a valid CSRF cookie (by GETting /register).
+    """
+    s = requests.Session()
+    s.auth = (USERNAME, PWD)
+    # seed the CSRF cookie (can be any GET endpoint that uses the middleware)
+    get_csrf_token(s, '/register')
+    return s
+
+
 def test_latest():
     # post something to update LATEST
     url = f"{BASE_URL}/register"

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -207,31 +207,42 @@ def test_register_c():
 
 
 def test_follow_user():
+    session = make_auth_session()
+    csrf = session.cookies['csrf_token']
+
     username = 'a'
     url = f'{BASE_URL}/fllws/{username}'
     data = {'follow': 'b'}
     params = {'latest': 7}
-    response = requests.post(url, data=json.dumps(data),
-                             headers=HEADERS, params=params)
-    assert response.ok
+    r = session.post(
+        url,
+        params=params,
+        data=json.dumps(data),
+        headers={**HEADERS, 'X-CSRF-Token': csrf}
+    )
+    assert r.ok
 
     data = {'follow': 'c'}
     params = {'latest': 8}
-    response = requests.post(url, data=json.dumps(data),
-                             headers=HEADERS, params=params)
-    assert response.ok
+    r = session.post(
+        url,
+        params=params,
+        data=json.dumps(data),
+        headers={**HEADERS, 'X-CSRF-Token': csrf}
+    )
+    assert r.ok
 
     query = {'no': 20, 'latest': 9}
-    response = requests.get(url, headers=HEADERS, params=query)
-    assert response.ok
+    r = session.get(url, headers=HEADERS, params=query)
+    assert r.ok
 
-    json_data = response.json()
+    json_data = r.json()
     assert "b" in json_data["follows"]
     assert "c" in json_data["follows"]
 
     # verify that latest was updated
-    response = requests.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert response.json()['latest'] == 9
+    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert r.json()['latest'] == 9
 
 
 def test_a_unfollows_b():

--- a/sim_api_test.py
+++ b/sim_api_test.py
@@ -124,23 +124,23 @@ def test_create_msg():
 
 
 def test_get_latest_user_msgs():
+    session = make_auth_session()
     username = 'a'
 
     query = {'no': 20, 'latest': 3}
     url = f'{BASE_URL}/msgs/{username}'
-    response = requests.get(url, headers=HEADERS, params=query)
-    assert response.status_code == 200
+    r = session.get(url, headers=HEADERS, params=query)
+    assert r.status_code == 200
 
-    got_it_earlier = False
-    for msg in response.json():
-        if msg['content'] == 'Blub!' and msg['user'] == username:
-            got_it_earlier = True
-
-    assert got_it_earlier
+    found = any(
+        msg['content'] == 'Blub!' and msg['user'] == username
+        for msg in r.json()
+    )
+    assert found
 
     # verify that latest was updated
-    response = requests.get(f'{BASE_URL}/latest', headers=HEADERS)
-    assert response.json()['latest'] == 3
+    r = session.get(f'{BASE_URL}/latest', headers=HEADERS)
+    assert r.json()['latest'] == 3
 
 
 def test_get_latest_msgs():

--- a/src/handlers/auth.go
+++ b/src/handlers/auth.go
@@ -58,6 +58,7 @@ func Login(c echo.Context) error {
 		"Error":   errorMessage,
 		"Flashes": flashes,
 	}
+	data = utils.MapCSRFToContext(c, data)
 	return c.Render(http.StatusOK, "login.html", data)
 }
 

--- a/src/handlers/auth.go
+++ b/src/handlers/auth.go
@@ -155,6 +155,7 @@ func Register(c echo.Context) error {
 		"Error":   errorMessage,
 		"Flashes": flashes,
 	}
+	data = utils.MapCSRFToContext(c, data)
 	return c.Render(http.StatusOK, "register.html", data)
 }
 

--- a/src/handlers/message.go
+++ b/src/handlers/message.go
@@ -265,5 +265,6 @@ func Timeline(c echo.Context) error {
 		"Endpoint": c.Path(),
 		"Flashes":  flashes,
 	}
+	data = utils.MapCSRFToContext(c, data)
 	return c.Render(http.StatusOK, "timeline.html", data)
 }

--- a/src/handlers/message.go
+++ b/src/handlers/message.go
@@ -183,6 +183,7 @@ func UserTimeline(c echo.Context) error {
 		"Endpoint":    c.Path(),
 		"Flashes":     flashes,
 	}
+	data = utils.MapCSRFToContext(c, data)
 	return c.Render(http.StatusOK, "timeline.html", data)
 }
 

--- a/src/handlers/message.go
+++ b/src/handlers/message.go
@@ -215,6 +215,7 @@ func PublicTimeline(c echo.Context) error {
 		"User":     user,
 		"Flashes":  flashes,
 	}
+	data = utils.MapCSRFToContext(c, data)
 	return c.Render(http.StatusOK, "timeline.html", data)
 }
 

--- a/src/main.go
+++ b/src/main.go
@@ -16,6 +16,7 @@ import (
 	"minitwit/src/snapshots"
 	"minitwit/src/template_rendering"
 	"minitwit/src/utils"
+	miniware "minitwit/src/middleware"
 )
 
 var SECRET_KEY = []byte("development key")
@@ -40,6 +41,8 @@ func main() {
 	repo_wrappers.InitRepos(db)
 
 	app.Use(session.Middleware(sessions.NewCookieStore(SECRET_KEY)))
+
+	app.Use(miniware.Csrf())
 
 	app.Use(middleware.StaticWithConfig(middleware.StaticConfig{
 		Root: "static", // static folder

--- a/src/main.go
+++ b/src/main.go
@@ -12,11 +12,11 @@ import (
 	"minitwit/src/datalayer"
 	"minitwit/src/handlers/repo_wrappers"
 	"minitwit/src/metrics"
+	miniware "minitwit/src/middleware"
 	"minitwit/src/routes"
 	"minitwit/src/snapshots"
 	"minitwit/src/template_rendering"
 	"minitwit/src/utils"
-	miniware "minitwit/src/middleware"
 )
 
 var SECRET_KEY = []byte("development key")

--- a/src/middleware/csrf.go
+++ b/src/middleware/csrf.go
@@ -1,16 +1,16 @@
 package middleware
 
 import (
-	"github.com/labstack/echo/v4/middleware"
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 )
 
 func Csrf() echo.MiddlewareFunc {
-  return middleware.CSRFWithConfig(middleware.CSRFConfig{
-        TokenLookup:	"header:X-CSRF-Token,form:_csrf",
-        CookieName:		"csrf_token",
-        CookiePath:		"/",
-        CookieHTTPOnly:	true,
-        CookieSecure:	false, // enable when serving HTTPS
-    })
+	return middleware.CSRFWithConfig(middleware.CSRFConfig{
+		TokenLookup:    "header:X-CSRF-Token,form:_csrf",
+		CookieName:     "csrf_token",
+		CookiePath:     "/",
+		CookieHTTPOnly: true,
+		CookieSecure:   false, // enable when serving HTTPS
+	})
 }

--- a/src/middleware/csrf.go
+++ b/src/middleware/csrf.go
@@ -1,0 +1,16 @@
+package middleware
+
+import (
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/labstack/echo/v4"
+)
+
+func Csrf() echo.MiddlewareFunc {
+  return middleware.CSRFWithConfig(middleware.CSRFConfig{
+        TokenLookup:	"header:X-CSRF-Token,form:_csrf",
+        CookieName:		"csrf_token",
+        CookiePath:		"/",
+        CookieHTTPOnly:	true,
+        CookieSecure:	false, // enable when serving HTTPS
+    })
+}

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -8,6 +8,7 @@
     <div class="error"><strong>Error:</strong> {{ .Error }}</div>
   {{ end }}
   <form action="/login" method="post">
+    <input type="hidden" name="_csrf" value="{{ .CSRFToken }}">
     <dl>
       <dt>Username:</dt>
       <dd><input type="text" name="username" size="30" value="{{ .Form.Username }}"></dd>

--- a/src/templates/register.html
+++ b/src/templates/register.html
@@ -8,6 +8,7 @@
     <div class="error"><strong>Error:</strong> {{ .Error }}</div>
   {{ end }}
   <form action="/register" method="post">
+    <input type="hidden" name="_csrf" value="{{ .CSRFToken }}">
     <dl>
       <dt>Username:</dt>
       <dd><input type="text" name="username" size="30" value="{{ .Form.Username }}"></dd>

--- a/src/templates/timeline.html
+++ b/src/templates/timeline.html
@@ -30,6 +30,7 @@
       <div class="twitbox">
         <h3>What's on your mind, {{ .User.Username }}?</h3>
         <form action="/add_message" method="post">
+          <input type="hidden" name="_csrf" value="{{ .CSRFToken }}">
           <p><input type="text" name="text" size="60">
           <input type="submit" value="Share">
         </form>

--- a/src/utils/csrf_token.go
+++ b/src/utils/csrf_token.go
@@ -1,0 +1,19 @@
+package utils
+
+import "github.com/labstack/echo/v4"
+
+func GetCsrfToken(c echo.Context) string {
+    tok, ok := c.Get("csrf").(string)
+    if !ok {
+        return ""
+    }
+    return tok
+}
+
+func MapCSRFToContext(c echo.Context, data map[string]interface{}) map[string]interface{} {
+    if data == nil {
+        data = make(map[string]interface{})
+    }
+    data["CSRFToken"] = GetCsrfToken(c)
+    return data
+}

--- a/src/utils/csrf_token.go
+++ b/src/utils/csrf_token.go
@@ -3,17 +3,17 @@ package utils
 import "github.com/labstack/echo/v4"
 
 func GetCsrfToken(c echo.Context) string {
-    tok, ok := c.Get("csrf").(string)
-    if !ok {
-        return ""
-    }
-    return tok
+	tok, ok := c.Get("csrf").(string)
+	if !ok {
+		return ""
+	}
+	return tok
 }
 
 func MapCSRFToContext(c echo.Context, data map[string]interface{}) map[string]interface{} {
-    if data == nil {
-        data = make(map[string]interface{})
-    }
-    data["CSRFToken"] = GetCsrfToken(c)
-    return data
+	if data == nil {
+		data = make(map[string]interface{})
+	}
+	data["CSRFToken"] = GetCsrfToken(c)
+	return data
 }


### PR DESCRIPTION
# Intro

CSRF (Cross-Site Request Forgery) is about tricking another user’s browser, while they’re already logged in to MiniTwit, into performing actions they didn’t intend.

In a CSRF attack, the attacker host a malicious page (the auto-submitting form in the Minitwit case), then any user who is already authenticated to MiniTwit (has a valid session cookie) and visits a malicious page will have their browser automatically execute hidden form submits using their own credentials.
The victim doesn’t have to fill out a form or click a button. Simply loading a page is enough to send the request.

This PR contains handling of security errors in cross site request forgery CSRF.

# Description
For each post request the CSRF token is validated, to mitigate malicious attempts to exploit csrf. Patched for both html and json requests.
A token is distributed to the user at the start of the user session (first GET request) and placed in cookies.

Tests have been updated to create user session and validate requests with token.

# Task relations
* Closes #152 