### PR TITLE
Task 153 security patch open monitoring ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ stop:
 docker stop minitwit_app
 ```
 
+## Monitoring
+
+To access grafana or prometheus, you must setup an ssh tunnel, using the following command:
+
+Windows:
+
+```bat
+ssh -L 3000:127.0.0.1:3000 root@droplet.ip.adress.here
+```
+
+- where port `3000` is the port served by Grafana, you can replace the ports with `9090` to have a tunnel to prometheus
+- `droplet.ip.adress.here` should be either `167.71.64.240` for test web, or `159.223.8.210` for prod web
+- (OBS! remember to white-list yourself on the firewall on digital ocean, as well as having setup the ssh access keys)
+
+Now you can access grana by:
+
+1. opening a browser
+2. navigate to `http://localhost:3000`
+
+And you should be redirected to the Grafana login page
+
 # Cleanup
 
 Remove image. It is not always necessary to use -f it is only when you want to force deletion:

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -16,8 +16,6 @@ services:
 
   grafana:
     build: !reset null
-    ports: !override
-      - "0.0.0.0:3000:3000"  
     volumes:
       - grafana-storage:/var/lib/grafana
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,11 @@ services:
       context: ./.infrastructure/prometheus
     image: ${DOCKER_USERNAME-}${DOCKER_USERNAME:+/}prometheus:${DOCKER_TAG:-local}
     container_name: prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--web.listen-address=127.0.0.1:9090"
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     networks:
       - main
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,8 +65,10 @@ services:
     image: ${DOCKER_USERNAME-}${DOCKER_USERNAME:+/}grafana:${DOCKER_TAG:-local}
     container_name: grafana
     ports:
-      - "3000:3000"  
+      - "127.0.0.1:3000:3000"
     environment:
+      - GF_SERVER_HTTP_ADDR=0.0.0.0
+      - GF_SERVER_HTTP_PORT=3000
       - PROMETHEUS_HOST=prometheus:9090
       - LOKI_HOST=loki:3100
     networks:


### PR DESCRIPTION
# Intro

This PR contains handling of security errors in open ports to monitoring tools

# Description
Both port `3000` (Grafana) and `9090` (Prometheus) were open for public internet.
Both ports has been closed and is only internally accessible.

The README has been updated guiding how to tunnel a server endpoint - to be able to view the monitoring.

# Task relations
* Closes #153