### PR TITLE
Task 157 security patch security headers

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -53,9 +53,9 @@ func main() {
 	app.Use(metrics.PrometheusMiddleware()) // For metrics
 
 	app.Use(middleware.SecureWithConfig(middleware.SecureConfig{
-        XFrameOptions: 			"DENY", // prevents clickjacking
-		ContentTypeNosniff:		"nosniff", // prevents content-type sniffing
-    }))
+		XFrameOptions:      "DENY",    // prevents clickjacking
+		ContentTypeNosniff: "nosniff", // prevents content-type sniffing
+	}))
 
 	app.Use(middleware.BodyLimit("2M")) // drop >2 MiB payloads early
 	app.Use(middleware.RateLimiter(


### PR DESCRIPTION
# Intro

This PR handles  security headers `X-Content-Type-Options` and `X-Frame-Options` protecting against content sniffing or media type sniffing (web browsers examine the content of a response) and clickjacking (manipulating a website user's activity by concealing hyperlinks beneath legitimate clickable content, thereby causing the user to perform actions of which they didnt intend to do), 

# Description
Before the routes have been setup - it is ensured that headers sets `X-Frame-Options = "DENY"` and `X-Content-Type-Options = "nosniff"`,
Setting `X-Frame-Option` means we are denying any kind of rendering of pages between multiple html tags (e.g. `<frame>`), see more about it [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options).
Setting `X-Content-Type-Options` means we force the browser to treat uploaded content as the type the server specify, instead of attempting to sniff the content themselves (e.g. if someone uploads malicious javascript code, and the server tells the browser that it is a string -and hence shouldn't be executed-, the browser will not attempt to look at it and go "that smells like JavaScrip! I know you said it was a string - but we all make mistakes. No worries, babe, I'll go ahead and execute this for you!" - and boom we hacked). See more about it [here](https://medium.com/@omid.jn/golang-and-x-content-type-options-e49895c1891a)

# Task relations
* Closes #155